### PR TITLE
Issue: Embedded maria does not support some unicode characters #13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ embedded.kafka.topicsToCreate=some_topic
 ```
 ##### Consumes
 * embedded.mariadb.enabled `(true|false, default is 'true')`
+* embedded.mariadb.encoding `(default is 'utf8mb4')`
+* embedded.mariadb.collation `(default is 'utf8mb4_unicode_ci')`
 * embedded.mariadb.dockerImage `(default is set to 'mariadb:10.3.2')`
   * You can pick wanted version on [dockerhub](https://hub.docker.com/r/library/mariadb/tags/)
 ##### Produces

--- a/embedded-mariadb/src/main/java/com/playtika/test/mariadb/EmbeddedMariaDBAutoConfiguration.java
+++ b/embedded-mariadb/src/main/java/com/playtika/test/mariadb/EmbeddedMariaDBAutoConfiguration.java
@@ -67,6 +67,9 @@ public class EmbeddedMariaDBAutoConfiguration {
                         .withEnv("MYSQL_USER", properties.getUser())
                         .withEnv("MYSQL_PASSWORD", properties.getPassword())
                         .withEnv("MYSQL_DATABASE", properties.getDatabase())
+                        .withCommand(
+                                "--character-set-server=" + properties.getEncoding(),
+                                "--collation-server=" + properties.getCollation())
                         .withLogConsumer(containerLogsConsumer(log))
                         .withExposedPorts(properties.port);
         mariadb.start();

--- a/embedded-mariadb/src/main/java/com/playtika/test/mariadb/MariaDBProperties.java
+++ b/embedded-mariadb/src/main/java/com/playtika/test/mariadb/MariaDBProperties.java
@@ -32,6 +32,9 @@ public class MariaDBProperties {
     static final String BEAN_NAME_EMBEDDED_MARIADB = "embeddedMariaDb";
     boolean enabled;
     String dockerImage = "mariadb:10.3.2";
+    String encoding = "utf8mb4";
+    String collation = "utf8mb4_unicode_ci";
+
     final String user = "mariadb";
     final String password = "letmein";
     final String database = "test_db";

--- a/embedded-mariadb/src/test/java/com/playtika/test/mariadb/EmbeddedMariaDBAutoConfigurationTest.java
+++ b/embedded-mariadb/src/test/java/com/playtika/test/mariadb/EmbeddedMariaDBAutoConfigurationTest.java
@@ -65,6 +65,14 @@ public class EmbeddedMariaDBAutoConfigurationTest {
     }
 
     @Test
+    public void shouldSaveAndGetUnicode() throws Exception {
+        jdbcTemplate.execute("CREATE TABLE employee(id INT, name VARCHAR(64));");
+        jdbcTemplate.execute("insert into employee (id, name) values (1, 'some data \uD83D\uDE22');");
+
+        assertThat(jdbcTemplate.queryForObject("select name from employee where id = 1", String.class)).isEqualTo("some data \uD83D\uDE22");
+    }
+
+    @Test
     public void propertiesAreAvailable() {
         assertThat(environment.getProperty("embedded.mariadb.port")).isNotEmpty();
         assertThat(environment.getProperty("embedded.mariadb.host")).isNotEmpty();


### PR DESCRIPTION
Link: https://github.com/Playtika/testcontainers-spring-boot/issues/13

Root cause: maria created with default charset utf-8 which allocates 3 bytes for single symbol,
but for some characters it needs to be 4
Resolution summary: added possibility to define encoding, set utf8mb4 as default encoding