### PR TITLE
Issue: some computers cannot start container in 30 seconds.

### DIFF
--- a/embedded-couchbase/src/test/java/com/playtika/test/couchbase/springdata/CouchbaseConfigurationProperties.java
+++ b/embedded-couchbase/src/test/java/com/playtika/test/couchbase/springdata/CouchbaseConfigurationProperties.java
@@ -28,7 +28,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 @Data
-@Validated
 @ConfigurationProperties(prefix = "couchbase")
 public class CouchbaseConfigurationProperties {
 

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/checks/KafkaStatusCheck.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/checks/KafkaStatusCheck.java
@@ -23,14 +23,14 @@
  */
 package com.playtika.test.kafka.checks;
 
-import com.playtika.test.common.checks.AbstractStartupCheckStrategy;
+import com.playtika.test.common.checks.AbstractCommandWaitStrategy;
 import com.playtika.test.kafka.properties.KafkaConfigurationProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public class KafkaStatusCheck extends AbstractStartupCheckStrategy {
+public class KafkaStatusCheck extends AbstractCommandWaitStrategy {
 
     private static final String MIN_BROKERS_COUNT = "1";
     private static final String TIMEOUT_IN_SEC = "30";
@@ -38,7 +38,7 @@ public class KafkaStatusCheck extends AbstractStartupCheckStrategy {
     private final KafkaConfigurationProperties properties;
 
     @Override
-    public String[] getHealthCheckCmd() {
+    public String[] getCheckCommand() {
         return new String[] {
                 "cub",
                 "kafka-ready",

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/checks/ZookeeperStatusCheck.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/checks/ZookeeperStatusCheck.java
@@ -23,21 +23,21 @@
  */
 package com.playtika.test.kafka.checks;
 
-import com.playtika.test.common.checks.AbstractStartupCheckStrategy;
+import com.playtika.test.common.checks.AbstractCommandWaitStrategy;
 import com.playtika.test.kafka.properties.ZookeeperConfigurationProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public class ZookeeperStatusCheck extends AbstractStartupCheckStrategy {
+public class ZookeeperStatusCheck extends AbstractCommandWaitStrategy {
 
     private static final String TIMEOUT_IN_SEC = "30";
 
     private final ZookeeperConfigurationProperties properties;
 
     @Override
-    public String[] getHealthCheckCmd() {
+    public String[] getCheckCommand() {
         return new String[]{
                 "cub",
                 "zk-ready",

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/configuration/KafkaContainerConfiguration.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/configuration/KafkaContainerConfiguration.java
@@ -82,7 +82,6 @@ public class KafkaContainerConfiguration {
         log.info("Starting kafka broker. Docker image: {}", kafkaProperties.getDockerImage());
 
         GenericContainer kafka = new FixedHostPortGenericContainer<>(kafkaProperties.getDockerImage())
-                .withStartupCheckStrategy(kafkaStatusCheck)
                 .withLogConsumer(containerLogsConsumer(log))
                 .withEnv("KAFKA_ZOOKEEPER_CONNECT", "zookeeper:" + zookeeperProperties.getZookeeperPort())
                 .withEnv("KAFKA_BROKER_ID", "-1")
@@ -91,7 +90,8 @@ public class KafkaContainerConfiguration {
                 .withFileSystemBind(kafkaData, "/var/lib/kafka/data", BindMode.READ_WRITE)
                 .withCreateContainerCmdModifier(cmd -> cmd.withLinks(new Link(zookeeperHostname, "zookeeper")))
                 .withExposedPorts(kafkaMappingPort)
-                .withFixedExposedPort(kafkaMappingPort, kafkaMappingPort);
+                .withFixedExposedPort(kafkaMappingPort, kafkaMappingPort)
+                .waitingFor(kafkaStatusCheck);
         kafka.start();
         registerKafkaEnvironment(kafka, environment, kafkaProperties);
         return kafka;

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/configuration/ZookeeperContainerConfiguration.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/configuration/ZookeeperContainerConfiguration.java
@@ -72,13 +72,13 @@ public class ZookeeperContainerConfiguration {
 
         int mappingPort = zookeeperProperties.getZookeeperPort();
         GenericContainer zookeeper = new FixedHostPortGenericContainer<>(zookeeperProperties.getDockerImage())
-                .withStartupCheckStrategy(zookeeperStatusCheck)
                 .withLogConsumer(containerLogsConsumer(log))
                 .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(mappingPort))
                 .withFileSystemBind(zkData, "/var/lib/zookeeper/data", BindMode.READ_WRITE)
                 .withFileSystemBind(zkTransactionLogs, "/var/lib/zookeeper/log", BindMode.READ_WRITE)
                 .withExposedPorts(mappingPort)
-                .withFixedExposedPort(mappingPort, mappingPort);
+                .withFixedExposedPort(mappingPort, mappingPort)
+                .waitingFor(zookeeperStatusCheck);
         zookeeper.start();
         registerZookeeperEnvironment(zookeeper, environment, zookeeperProperties);
         return zookeeper;

--- a/embedded-mariadb/src/main/java/com/playtika/test/mariadb/EmbeddedMariaDBAutoConfiguration.java
+++ b/embedded-mariadb/src/main/java/com/playtika/test/mariadb/EmbeddedMariaDBAutoConfiguration.java
@@ -61,7 +61,6 @@ public class EmbeddedMariaDBAutoConfiguration {
 
         GenericContainer mariadb =
                 new GenericContainer(properties.dockerImage)
-                        .withStartupCheckStrategy(mariaDBStatusCheck)
                         .withEnv("MYSQL_ALLOW_EMPTY_PASSWORD", "true")
                         .withEnv("MYSQL_USER", properties.getUser())
                         .withEnv("MYSQL_PASSWORD", properties.getPassword())
@@ -70,7 +69,8 @@ public class EmbeddedMariaDBAutoConfiguration {
                                 "--character-set-server=" + properties.getEncoding(),
                                 "--collation-server=" + properties.getCollation())
                         .withLogConsumer(containerLogsConsumer(log))
-                        .withExposedPorts(properties.port);
+                        .withExposedPorts(properties.port)
+                        .waitingFor(mariaDBStatusCheck);
         mariadb.start();
         registerMariadbEnvironment(mariadb, environment, properties);
         return mariadb;

--- a/embedded-mariadb/src/main/java/com/playtika/test/mariadb/MariaDBStatusCheck.java
+++ b/embedded-mariadb/src/main/java/com/playtika/test/mariadb/MariaDBStatusCheck.java
@@ -23,23 +23,22 @@
  */
 package com.playtika.test.mariadb;
 
-import com.playtika.test.common.checks.AbstractStartupCheckStrategy;
+import com.playtika.test.common.checks.AbstractCommandWaitStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public class MariaDBStatusCheck extends AbstractStartupCheckStrategy {
+public class MariaDBStatusCheck extends AbstractCommandWaitStrategy {
 
     @Override
-    public String[] getHealthCheckCmd() {
+    public String[] getCheckCommand() {
         return new String[] {
                 "mysql",
                 "-h",
                 "127.0.0.1",
                 "-e",
                 "SELECT 1"
-
         };
     }
 }

--- a/embedded-memsql/src/main/java/com/playtika/test/memsql/EmbeddedMemSqlAutoConfiguration.java
+++ b/embedded-memsql/src/main/java/com/playtika/test/memsql/EmbeddedMemSqlAutoConfiguration.java
@@ -62,13 +62,13 @@ public class EmbeddedMemSqlAutoConfiguration {
 
         GenericContainer memsql = new GenericContainer<>(properties.dockerImage)
                 .withEnv("IGNORE_MIN_REQUIREMENTS", "1")
-                .withStartupCheckStrategy(memSqlStatusCheck)
                 .withLogConsumer(containerLogsConsumer(log))
                 .withExposedPorts(properties.port)
                 .withClasspathResourceMapping(
                         "mem.sql",
                         "/schema.sql",
-                        BindMode.READ_ONLY);
+                        BindMode.READ_ONLY)
+                .waitingFor(memSqlStatusCheck);
         memsql.start();
         registerMemSqlEnvironment(memsql, environment, properties);
         return memsql;

--- a/embedded-memsql/src/main/java/com/playtika/test/memsql/MemSqlStatusCheck.java
+++ b/embedded-memsql/src/main/java/com/playtika/test/memsql/MemSqlStatusCheck.java
@@ -23,16 +23,16 @@
  */
 package com.playtika.test.memsql;
 
-import com.playtika.test.common.checks.AbstractStartupCheckStrategy;
+import com.playtika.test.common.checks.AbstractCommandWaitStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public class MemSqlStatusCheck extends AbstractStartupCheckStrategy {
+public class MemSqlStatusCheck extends AbstractCommandWaitStrategy {
 
     @Override
-    public String[] getHealthCheckCmd() {
+    public String[] getCheckCommand() {
         return new String[]{
                 "mysql",
                 "-u",

--- a/embedded-neo4j/src/main/java/com/playtika/test/neo4j/EmbeddedNeo4jAutoConfiguration.java
+++ b/embedded-neo4j/src/main/java/com/playtika/test/neo4j/EmbeddedNeo4jAutoConfiguration.java
@@ -55,23 +55,21 @@ public class EmbeddedNeo4jAutoConfiguration {
     @Bean(name = BEAN_NAME_EMBEDDED_NEO4J, destroyMethod = "stop")
     public GenericContainer neo4j(ConfigurableEnvironment environment,
                                   Neo4jProperties properties,
-                                  Neo4jStatusCheck Neo4jStatusCheck) throws Exception {
+                                  Neo4jStatusCheck neo4jStatusCheck) throws Exception {
 
         log.info("Starting neo4j server. Docker image: {}", properties.dockerImage);
 
-        GenericContainer neo4j =
-                new GenericContainer(properties.dockerImage)
-                        .withStartupCheckStrategy(Neo4jStatusCheck)
-                        .withLogConsumer(containerLogsConsumer(log))
-                        .withExposedPorts(
-                                properties.httpsPort
-                                , properties.httpPort
-                                , properties.boltPort)
-                        .withClasspathResourceMapping(
-                                "neo4j-health.sh",
-                                "/neo4j-health.sh",
-                                BindMode.READ_ONLY
-                        );
+        GenericContainer neo4j = new GenericContainer(properties.dockerImage)
+                .withLogConsumer(containerLogsConsumer(log))
+                .withExposedPorts(
+                        properties.httpsPort,
+                        properties.httpPort,
+                        properties.boltPort)
+                .withClasspathResourceMapping(
+                        "neo4j-health.sh",
+                        "/neo4j-health.sh",
+                        BindMode.READ_ONLY)
+                .waitingFor(neo4jStatusCheck);
         neo4j.start();
         registerNeo4jEnvironment(neo4j, environment, properties);
         return neo4j;

--- a/embedded-neo4j/src/main/java/com/playtika/test/neo4j/Neo4jStatusCheck.java
+++ b/embedded-neo4j/src/main/java/com/playtika/test/neo4j/Neo4jStatusCheck.java
@@ -23,7 +23,7 @@
  */
 package com.playtika.test.neo4j;
 
-import com.playtika.test.common.checks.AbstractStartupCheckStrategy;
+import com.playtika.test.common.checks.AbstractCommandWaitStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -32,10 +32,10 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class Neo4jStatusCheck extends AbstractStartupCheckStrategy {
+public class Neo4jStatusCheck extends AbstractCommandWaitStrategy {
 
     @Override
-    public String[] getHealthCheckCmd() {
+    public String[] getCheckCommand() {
         return new String[]{
                 "bash", "/neo4j-health.sh"
         };

--- a/embedded-redis/src/main/java/com/playtika/test/redis/EmbeddedRedisAutoConfiguration.java
+++ b/embedded-redis/src/main/java/com/playtika/test/redis/EmbeddedRedisAutoConfiguration.java
@@ -63,7 +63,6 @@ public class EmbeddedRedisAutoConfiguration {
 
         GenericContainer redis =
                 new GenericContainer(properties.dockerImage)
-                        .withStartupCheckStrategy(redisStatusCheck)
                         .withLogConsumer(containerLogsConsumer(log))
                         .withExposedPorts(properties.port)
                         .withEnv("REDIS_USER", properties.getUser())
@@ -72,8 +71,8 @@ public class EmbeddedRedisAutoConfiguration {
                         .withClasspathResourceMapping(
                                 "redis-health.sh",
                                 "/redis-health.sh",
-                                BindMode.READ_ONLY
-                        );
+                                BindMode.READ_ONLY)
+                        .waitingFor(redisStatusCheck);
         redis.start();
         registerRedisEnvironment(redis, environment, properties);
         return redis;

--- a/embedded-redis/src/main/java/com/playtika/test/redis/RedisStatusCheck.java
+++ b/embedded-redis/src/main/java/com/playtika/test/redis/RedisStatusCheck.java
@@ -23,16 +23,16 @@
  */
 package com.playtika.test.redis;
 
-import com.playtika.test.common.checks.AbstractStartupCheckStrategy;
+import com.playtika.test.common.checks.AbstractCommandWaitStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public class RedisStatusCheck extends AbstractStartupCheckStrategy {
+public class RedisStatusCheck extends AbstractCommandWaitStrategy {
 
     @Override
-    public String[] getHealthCheckCmd() {
+    public String[] getCheckCommand() {
         return new String[] {
                 "bash", "/redis-health.sh"
         };

--- a/embedded-redis/src/test/resources/log4j2.xml
+++ b/embedded-redis/src/test/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="com.playtika.test" level="debug"/>
+        <Logger name="com.playtika.test" level="info"/>
         <Logger name="org.springframework" level="error"/>
         <Root level="error">
             <AppenderRef ref="console"/>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
 
-        <testcontainers.version>1.4.2</testcontainers.version>
+        <testcontainers.version>1.5.0</testcontainers.version>
         <spring.cloud.version>Dalston.SR4</spring.cloud.version>
         <docker-java.version>3.0.14</docker-java.version>
 

--- a/testcontainers-common/src/main/java/com/playtika/test/common/checks/AbstractInitOnStartupStrategy.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/checks/AbstractInitOnStartupStrategy.java
@@ -23,29 +23,23 @@
  */
 package com.playtika.test.common.checks;
 
-import com.github.dockerjava.api.DockerClient;
-
-public abstract class AbstractInitOnStartupStrategy extends AbstractStartupCheckStrategy {
+public abstract class AbstractInitOnStartupStrategy extends AbstractCommandWaitStrategy {
 
     private volatile boolean wasExecutedOnce;
 
-    public abstract String [] getScriptToExecute();
+    public abstract String[] getScriptToExecute();
 
     @Override
-    public String[] getHealthCheckCmd() {
+    public String[] getCheckCommand() {
         return getScriptToExecute();
     }
 
     @Override
-    public StartupStatus checkStartupState(DockerClient dockerClient, String containerId) {
+    protected void waitUntilReady() {
         if (wasExecutedOnce) {
-            return StartupStatus.SUCCESSFUL;
+            return;
         }
-        StartupStatus startupStatus = super.checkStartupState(dockerClient, containerId);
-        if (startupStatus == StartupStatus.SUCCESSFUL) {
-            wasExecutedOnce = true;
-            return StartupStatus.SUCCESSFUL;
-        }
-        return StartupStatus.NOT_YET_KNOWN;
+        super.waitUntilReady();
+        wasExecutedOnce = true;
     }
 }

--- a/testcontainers-common/src/main/java/com/playtika/test/common/utils/ContainerUtils.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/utils/ContainerUtils.java
@@ -28,6 +28,7 @@ import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
 import lombok.Value;
+import lombok.experimental.UtilityClass;
 import org.slf4j.Logger;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.OutputFrame;
@@ -36,16 +37,19 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
+@UtilityClass
 public class ContainerUtils {
 
+    public static final Duration DEFAULT_CONTAINER_WAIT_DURATION = Duration.ofSeconds(60);
+
     public static int getAvailableMappingPort() {
-        try (ServerSocket socket = new ServerSocket(0)){
+        try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new IllegalStateException("Cannot find available port for mapping: " + e.getMessage(), e);
         }
     }
@@ -86,10 +90,9 @@ public class ContainerUtils {
         String cmdStdout;
         String cmdStderr;
 
-        try(ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-            ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-            ExecStartResultCallback cmdCallback = new ExecStartResultCallback(stdout, stderr))
-        {
+        try (ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+             ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+             ExecStartResultCallback cmdCallback = new ExecStartResultCallback(stdout, stderr)) {
             dockerClient.execStartCmd(cmd.getId()).exec(cmdCallback).awaitCompletion();
             cmdStdout = stdout.toString(StandardCharsets.UTF_8.name());
             cmdStderr = stderr.toString(StandardCharsets.UTF_8.name());
@@ -108,4 +111,5 @@ public class ContainerUtils {
         int exitCode;
         String output;
     }
+
 }

--- a/testcontainers-common/src/test/java/com/playtika/test/common/checks/AbstractCommandWaitStrategyTest.java
+++ b/testcontainers-common/src/test/java/com/playtika/test/common/checks/AbstractCommandWaitStrategyTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 
-public class AbstractStartupCheckStrategyTest {
+public class AbstractCommandWaitStrategyTest {
 
     private static final GenericContainer TEST_CONTAINER = new GenericContainer("alpine:latest")
             .withCommand("/bin/sh", "-c", "while true; do echo 'Press [CTRL+C] to stop..'; sleep 1; done");
@@ -35,18 +35,18 @@ public class AbstractStartupCheckStrategyTest {
     @Test
     public void should_passStartupChecks_andStartContainer() {
         TEST_CONTAINER
-                .withStartupCheckStrategy(new PositiveStartupCheckStrategy())
+                .waitingFor(new PositiveCommandWaitStrategy())
                 .start();
     }
 
     @Test(expected = ContainerLaunchException.class)
     public void should_failStartupChecks_ifHealthCheckCmdIsFailed() {
         TEST_CONTAINER
-                .withStartupCheckStrategy(new NegativeStartupCheckStrategy())
+                .waitingFor(new NegativeCommandWaitStrategy())
                 .start();
     }
 
-    private static class PositiveStartupCheckStrategy extends AbstractStartupCheckStrategy {
+    private static class PositiveCommandWaitStrategy extends AbstractCommandWaitStrategy {
 
         @Override
         public String getContainerType() {
@@ -54,12 +54,12 @@ public class AbstractStartupCheckStrategyTest {
         }
 
         @Override
-        public String[] getHealthCheckCmd() {
+        public String[] getCheckCommand() {
             return new String[] {"echo", "health check passed"};
         }
     }
 
-    private static class NegativeStartupCheckStrategy extends AbstractStartupCheckStrategy {
+    private static class NegativeCommandWaitStrategy extends AbstractCommandWaitStrategy {
 
         @Override
         public String getContainerType() {
@@ -67,7 +67,7 @@ public class AbstractStartupCheckStrategyTest {
         }
 
         @Override
-        public String[] getHealthCheckCmd() {
+        public String[] getCheckCommand() {
             return new String[] {"/bin/sh", "-c", "invalid command"};
         }
     }


### PR DESCRIPTION
Root cause:
All check are being performed at startup check phase with has hardcoded 30 seconds timeout
Resolution summary:
Move checks from startupCheckStrategies to WaitStrategies which allow to configure timeout