### PR TITLE
Make list of bean dependencies mutable

### DIFF
--- a/testcontainers-common/src/main/java/com/playtika/test/common/spring/DependsOnPostProcessor.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/spring/DependsOnPostProcessor.java
@@ -63,6 +63,6 @@ public class DependsOnPostProcessor implements BeanFactoryPostProcessor {
     }
 
     private static List<String> asList(String[] array) {
-        return (array == null ? new ArrayList<>() : Arrays.asList(array));
+        return (array == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(array)));
     }
 }

--- a/testcontainers-common/src/test/java/com/playtika/test/common/spring/DependsOnPostProcessorTest.java
+++ b/testcontainers-common/src/test/java/com/playtika/test/common/spring/DependsOnPostProcessorTest.java
@@ -1,0 +1,64 @@
+package com.playtika.test.common.spring;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DependsOnPostProcessorTest {
+
+    private static final String TEST_BEAN_NAME_3 = "testBean3";
+    private static final String TEST_BEAN_NAME_4 = "testBean4";
+    private static final String TEST_BEAN_NAME_1 = "testBean1";
+    private static final String TEST_BEAN_NAME_2 = "testBean2";
+    private static final String TEST_PROCESSOR_BEAN = "testProcessorBean";
+
+    private DependsOnPostProcessor dependsOnPostProcessor;
+
+    @Mock
+    private ConfigurableListableBeanFactory configurableListableBeanFactory;
+    @Mock
+    private BeanDefinition beanDefinition;
+
+    @Before
+    public void setUp() {
+        dependsOnPostProcessor = new DependsOnPostProcessor(TestProcessor.class, new String[]{TEST_BEAN_NAME_3, TEST_BEAN_NAME_4});
+    }
+
+    @Test
+    public void shouldExtendListOfBeanDependenciesIfBeanDefinitionAlreadyContainsDependencies() {
+        when(configurableListableBeanFactory.getBeanNamesForType(TestProcessor.class, true, true)).thenReturn(new String[]{TEST_PROCESSOR_BEAN});
+        when(configurableListableBeanFactory.getBeanDefinition(TEST_PROCESSOR_BEAN)).thenReturn(beanDefinition);
+        when(beanDefinition.getDependsOn()).thenReturn(new String[]{TEST_BEAN_NAME_1, TEST_BEAN_NAME_2});
+
+        dependsOnPostProcessor.postProcessBeanFactory(configurableListableBeanFactory);
+
+        String[] expected = {TEST_BEAN_NAME_1, TEST_BEAN_NAME_2, TEST_BEAN_NAME_3, TEST_BEAN_NAME_4};
+
+        verify(beanDefinition, times(1)).setDependsOn(expected);
+    }
+
+    @Test
+    public void shouldExtendListOfBeanDependenciesIfBeanDefinitionDoesNotContainDependencies() {
+        when(configurableListableBeanFactory.getBeanNamesForType(TestProcessor.class, true, true)).thenReturn(new String[]{TEST_PROCESSOR_BEAN});
+        when(configurableListableBeanFactory.getBeanDefinition(TEST_PROCESSOR_BEAN)).thenReturn(beanDefinition);
+        when(beanDefinition.getDependsOn()).thenReturn(null);
+
+        dependsOnPostProcessor.postProcessBeanFactory(configurableListableBeanFactory);
+
+        String[] expected = {TEST_BEAN_NAME_3, TEST_BEAN_NAME_4};
+
+        verify(beanDefinition, times(1)).setDependsOn(expected);
+    }
+
+    private static class TestProcessor {
+    }
+}


### PR DESCRIPTION
Make list of bean dependencies mutable due to UnsupportedOperationException in case dataSourceBeanDefinition.getDependsOn() is not empty