### PR TITLE
Postresql, Redis - use alpine based image

### DIFF
--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
@@ -33,7 +33,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("embedded.postgresql")
 public class PostgreSQLProperties extends CommonContainerProperties {
     static final String BEAN_NAME_EMBEDDED_POSTGRESQL = "embeddedPostgreSql";
-    String dockerImage = "postgres:10.3";
+    String dockerImage = "postgres:10.3-alpine";
 
     String user = "postgresql";
     String password = "letmein";

--- a/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
+++ b/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
@@ -33,7 +33,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("embedded.redis")
 public class RedisProperties extends CommonContainerProperties {
     static final String BEAN_NAME_EMBEDDED_REDIS = "embeddedRedis";
-    public String dockerImage = "redis:4.0.12";
+    public String dockerImage = "redis:4.0.12-alpine";
     public String user = "root";
     public String password = "passw";
     public String host = "localhost";


### PR DESCRIPTION
Use Alpine-based images of PostgreSQL and Redis containers since they have much smaller size.