### PR TITLE
Add ability to specify clickhouse compatible image

### DIFF
--- a/embedded-clickhouse/README.adoc
+++ b/embedded-clickhouse/README.adoc
@@ -17,6 +17,7 @@
 * `embedded.clickhouse.enabled` `(true|false, default is 'true')`
 * `embedded.clickhouse.reuseContainer` `(true|false, default is 'false')`
 * `embedded.clickhouse.dockerImage` `(default is set to 'yandex/clickhouse-server:20.5')`
+* `embedded.clickhouse.asCompatibleImage` `(true|false, default is 'false')`
 
 ==== Produces
 

--- a/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/ClickHouseProperties.java
+++ b/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/ClickHouseProperties.java
@@ -33,7 +33,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("embedded.clickhouse")
 public class ClickHouseProperties extends CommonContainerProperties {
     static final String BEAN_NAME_EMBEDDED_CLICK_HOUSE = "embeddedClickHouse";
-    String dockerImage = "yandex/clickhouse-server:20.5";
+    static final String DEFAULT_DOCKER_IMAGE = "yandex/clickhouse-server";
+    static final String DEFAULT_DOCKER_IMAGE_TAG = "20.5";
+    String dockerImage = DEFAULT_DOCKER_IMAGE + ":" + DEFAULT_DOCKER_IMAGE_TAG;
     String host = "localhost";
     int port = 8123;
+    Boolean asCompatibleImage = false;
 }

--- a/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/EmbeddedClickHouseBootstrapConfiguration.java
+++ b/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/EmbeddedClickHouseBootstrapConfiguration.java
@@ -34,10 +34,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.LinkedHashMap;
 
 import static com.playtika.test.clickhouse.ClickHouseProperties.BEAN_NAME_EMBEDDED_CLICK_HOUSE;
+import static com.playtika.test.clickhouse.ClickHouseProperties.DEFAULT_DOCKER_IMAGE;
 import static com.playtika.test.common.utils.ContainerUtils.configureCommonsAndStart;
 
 @Slf4j
@@ -53,7 +55,13 @@ public class EmbeddedClickHouseBootstrapConfiguration {
                                                            ClickHouseProperties properties) {
         log.info("Starting ClickHouse server. Docker image: {}", properties.getDockerImage());
 
-        ConcreteClickHouseContainer clickHouseContainer = new ConcreteClickHouseContainer(properties.dockerImage);
+        DockerImageName dockerImageName = DockerImageName.parse(properties.dockerImage);
+
+        if (properties.asCompatibleImage) {
+            dockerImageName = dockerImageName.asCompatibleSubstituteFor(DEFAULT_DOCKER_IMAGE);
+        }
+
+        ConcreteClickHouseContainer clickHouseContainer = new ConcreteClickHouseContainer(dockerImageName);
 
         clickHouseContainer = (ConcreteClickHouseContainer) configureCommonsAndStart(clickHouseContainer, properties, log);
 
@@ -82,7 +90,7 @@ public class EmbeddedClickHouseBootstrapConfiguration {
     }
 
     private static class ConcreteClickHouseContainer extends ClickHouseContainer {
-        public ConcreteClickHouseContainer(String dockerImageName) {
+        public ConcreteClickHouseContainer(DockerImageName dockerImageName) {
             super(dockerImageName);
         }
     }


### PR DESCRIPTION
#541 

Add property `embedded.clickhouse.asCompatibleImage` `(true|false, default is 'false')` to be able to use an image other then the default 