### PR TITLE
Remove remote webdriver as bean because it is closed/reseted by Spring

### DIFF
--- a/embedded-selenium/readme.adoc
+++ b/embedded-selenium/readme.adoc
@@ -77,7 +77,7 @@ An example test class would look like the following:
 
 [source,java]
 -----------------
-@RunWith(SpringRunner.class)
+import org.openqa.selenium.WebDriver;@RunWith(SpringRunner.class)
 @SpringBootTest(
         classes = SpringBootWebApplication.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
@@ -92,12 +92,13 @@ public class TestLoginPage {
     private String hostname;
 
     @Autowired
-    private RemoteWebDriver remoteWebDriver;
+    private BrowserWebDriverContainer webDriverContainer;
 
     @Test
     public void test1() {
-        remoteWebDriver.get("https://" + hostname +":" + port);
-        assertThat(remoteWebDriver.getPageSource()).contains("helloworld");
+        RemoteWebDriver webDriver = webDriverContainer.getWebDriver();
+        webDriver.get("https://" + hostname +":" + port);
+        assertThat(webDriver.getPageSource()).contains("helloworld");
     }
 
     @TestConfiguration

--- a/embedded-selenium/src/main/java/com/playtika/test/selenium/EmbeddedSeleniumBootstrapConfiguration.java
+++ b/embedded-selenium/src/main/java/com/playtika/test/selenium/EmbeddedSeleniumBootstrapConfiguration.java
@@ -123,13 +123,6 @@ public class EmbeddedSeleniumBootstrapConfiguration {
         return container;
     }
 
-    @Bean(name = BEAN_NAME_EMBEDDED_SELENIUM_DRIVER)
-    public RemoteWebDriver driver(
-            BrowserWebDriverContainer container
-    ) {
-        return container.getWebDriver();
-    }
-
     /**
      * Testcontainers does not expose its default vnc dir when it is not
      * defined, so we recreate this implementation here.


### PR DESCRIPTION
During testing, the WebDriverTestExecutionListener from Spring closes the webdriver and it does not work any more. Only the container object should control the lifecycle of the webdriver no other unexpected things. Therefore the webdriver object should not be a bean.

To get the webdriver you will need to inject the container and call container.getWebDriver().

After discovering WebDriverTestExecutionListener I noticed there was no TestcontainerTestExecutionListener which would probably be required for all Testcontainer implementations as testcontainers implement the interface org.testcontainers.lifecycle.TestLifecycleAware. I will create another pull request for this because of another bug.