### PR TITLE
Fix save videos in selenium module (now with 1 commit)

### DIFF
--- a/embedded-selenium/pom.xml
+++ b/embedded-selenium/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
             <optional>true</optional>
         </dependency>
 

--- a/embedded-selenium/readme.adoc
+++ b/embedded-selenium/readme.adoc
@@ -17,9 +17,11 @@
 * `embedded.selenium.enabled` `(boolean, true|false, default is 'true')`
 * `embedded.selenium.browser` `(enum, FIREFOX|CHROMIUM, default is 'CHROMIUM')`
 
+* `embedded.selenium.vnc.mode` `RECORD_ALL | SKIP | RECORD_FAILING`
+* `embedded.selenium.vnc.recording-dir` `a file location`
+
 
 ==== Produces
-
 
 * `embedded.selenium.port`
 * `embedded.selenium.host`

--- a/embedded-selenium/src/main/java/com/playtika/test/selenium/testscope/TestcontainerContextCustomizerFactory.java
+++ b/embedded-selenium/src/main/java/com/playtika/test/selenium/testscope/TestcontainerContextCustomizerFactory.java
@@ -1,0 +1,41 @@
+package com.playtika.test.selenium.testscope;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.MergedContextConfiguration;
+
+import java.util.List;
+
+public class TestcontainerContextCustomizerFactory implements ContextCustomizerFactory {
+    @Override
+    public ContextCustomizer createContextCustomizer(Class<?> testClass,
+                                                     List<ContextConfigurationAttributes> configAttributes) {
+        return new Customizer();
+    }
+
+    private static class Customizer implements ContextCustomizer {
+
+        @Override
+        public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+            TestcontainerScope.registerWith(context);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null || obj.getClass() != getClass()) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return getClass().hashCode();
+        }
+    }
+}

--- a/embedded-selenium/src/main/java/com/playtika/test/selenium/testscope/TestcontainerScope.java
+++ b/embedded-selenium/src/main/java/com/playtika/test/selenium/testscope/TestcontainerScope.java
@@ -1,0 +1,133 @@
+package com.playtika.test.selenium.testscope;
+
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.Scope;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+import org.testcontainers.lifecycle.TestDescription;
+import org.testcontainers.lifecycle.TestLifecycleAware;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class TestcontainerScope implements Scope {
+    public static final String NAME = "testcontainer";
+
+    private static final String TEST_CONTAINER_CLASS = "org.testcontainers.containers.GenericContainer";
+
+    private static final String[] BEAN_CLASSES = { TEST_CONTAINER_CLASS };
+
+    private final Map<String, Object> instances = new HashMap<>();
+
+    @Override
+    public Object get(String name, ObjectFactory<?> objectFactory) {
+        synchronized (this.instances) {
+            Object instance = this.instances.get(name);
+            if (instance == null) {
+                instance = objectFactory.getObject();
+                this.instances.put(name, instance);
+            }
+            return instance;
+        }
+    }
+
+    @Override
+    public Object remove(String name) {
+        synchronized (this.instances) {
+            return this.instances.remove(name);
+        }
+    }
+
+    @Override
+    public void registerDestructionCallback(String name, Runnable callback) {
+    }
+
+    @Override
+    public Object resolveContextualObject(String key) {
+        return null;
+    }
+
+    @Override
+    public String getConversationId() {
+        return null;
+    }
+
+    /**
+     * Register this scope with the specified context and reassign appropriate bean
+     * definitions to used it.
+     * @param context the application context
+     */
+    static void registerWith(ConfigurableApplicationContext context) {
+        if (!ClassUtils.isPresent(TEST_CONTAINER_CLASS, null)) {
+            return;
+        }
+        ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+        if (beanFactory.getRegisteredScope(NAME) == null) {
+            beanFactory.registerScope(NAME, new TestcontainerScope());
+        }
+        context.addBeanFactoryPostProcessor(TestcontainerScope::postProcessBeanFactory);
+    }
+
+    private static void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) {
+        for (String beanClass : BEAN_CLASSES) {
+            for (String beanName : beanFactory.getBeanNamesForType(ClassUtils.resolveClassName(beanClass, null))) {
+                BeanDefinition definition = beanFactory.getBeanDefinition(beanName);
+                if (!StringUtils.hasLength(definition.getScope())) {
+                    definition.setScope(NAME);
+                }
+            }
+        }
+    }
+
+    /**
+     * Return the {@link TestcontainerScope} being used by the specified context (if any).
+     * @param context the application context
+     * @return the web driver scope or {@code null}
+     */
+    static TestcontainerScope getFrom(ApplicationContext context) {
+        if (context instanceof ConfigurableApplicationContext) {
+            Scope scope = ((ConfigurableApplicationContext) context).getBeanFactory().getRegisteredScope(NAME);
+            return (scope instanceof TestcontainerScope) ? (TestcontainerScope) scope : null;
+        }
+        return null;
+    }
+
+    public void afterTestMethod(TestContext testContext) {
+        instances.values().stream()
+                .filter(TestLifecycleAware.class::isInstance)
+                .map(TestLifecycleAware.class::cast)
+                .forEach(value -> {
+                    value.afterTest(testDescription(testContext), Optional.ofNullable(testContext.getTestException()));
+                });
+     }
+
+    private TestDescription testDescription(TestContext testContext) {
+        return new TestDescription() {
+
+            @Override
+            public String getTestId() {
+                return getFilesystemFriendlyName();
+            }
+
+            @Override
+            public String getFilesystemFriendlyName() {
+                return testContext.getTestClass().getName() + "-" +  testContext.getTestMethod().getName();
+            }
+        };
+    }
+
+    public void beforeTestMethod(TestContext testContext) {
+        instances.values().stream()
+                .filter(TestLifecycleAware.class::isInstance)
+                .map(TestLifecycleAware.class::cast)
+                .forEach(value -> {
+                    value.beforeTest(testDescription(testContext));
+                });
+    }
+}

--- a/embedded-selenium/src/main/java/com/playtika/test/selenium/testscope/TestcontainerTestExecutionListener.java
+++ b/embedded-selenium/src/main/java/com/playtika/test/selenium/testscope/TestcontainerTestExecutionListener.java
@@ -1,0 +1,30 @@
+package com.playtika.test.selenium.testscope;
+
+import org.springframework.core.Ordered;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+public class TestcontainerTestExecutionListener extends AbstractTestExecutionListener {
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 100;
+    }
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) {
+        TestcontainerScope scope = TestcontainerScope.getFrom(testContext.getApplicationContext());
+        scope.beforeTestMethod(testContext);
+    }
+
+    @Override
+    public void afterTestMethod(TestContext testContext) {
+        TestcontainerScope scope = TestcontainerScope.getFrom(testContext.getApplicationContext());
+        scope.afterTestMethod(testContext);
+        if (scope != null ) {
+            testContext.setAttribute(DependencyInjectionTestExecutionListener.REINJECT_DEPENDENCIES_ATTRIBUTE,
+                    Boolean.TRUE);
+        }
+    }
+}

--- a/embedded-selenium/src/main/resources/META-INF/spring.factories
+++ b/embedded-selenium/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,10 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 com.playtika.test.selenium.EmbeddedSeleniumBootstrapConfiguration
+
+# Spring Test ContextCustomizerFactories
+org.springframework.test.context.ContextCustomizerFactory=\
+   com.playtika.test.selenium.testscope.TestcontainerContextCustomizerFactory
+
+org.springframework.test.context.TestExecutionListener=\
+  com.playtika.test.selenium.testscope.TestcontainerTestExecutionListener
+

--- a/embedded-selenium/src/test/java/com/playtika/test/selenium/drivers/VncRecordingRecordAllUserDefinesDirTest.java
+++ b/embedded-selenium/src/test/java/com/playtika/test/selenium/drivers/VncRecordingRecordAllUserDefinesDirTest.java
@@ -57,13 +57,17 @@ public class VncRecordingRecordAllUserDefinesDirTest extends BaseEmbeddedSeleniu
     @Autowired
     public ChromeOptions options;
 
-    @Value("${embedded.selenium.vnc.record-dir}")
+    @Value("${embedded.selenium.vnc.recording-dir}")
     private String recordDir;
 
 
     @AfterAll
     public void cleanupTmpDir() {
         File dirToDelete = new File(recordDir);
+        assertThat(dirToDelete.list()).isNotEmpty();
+
+        //assert that all tests generated a video
+        assertThat(dirToDelete.list().length).isEqualTo(5);
         if (dirToDelete.exists()) {
             FileSystemUtils.deleteRecursively(new File(recordDir));
         }
@@ -86,8 +90,8 @@ public class VncRecordingRecordAllUserDefinesDirTest extends BaseEmbeddedSeleniu
         assertThat(environment.getProperty("embedded.selenium.vnc.mode")).isEqualTo("RECORD_ALL");
         assertThat(environment.getProperty("embedded.selenium.vnc.wassetintest")).isEqualTo("true");
 
-        assertThat(environment.getProperty("embedded.selenium.vnc.record-dir")).isNotEmpty();
-        File recordDir = new File(environment.getProperty("embedded.selenium.vnc.record-dir"));
+        assertThat(environment.getProperty("embedded.selenium.vnc.recording-dir")).isNotEmpty();
+        File recordDir = new File(environment.getProperty("embedded.selenium.vnc.recording-dir"));
         assertThat(recordDir).exists();
     }
 
@@ -99,7 +103,7 @@ public class VncRecordingRecordAllUserDefinesDirTest extends BaseEmbeddedSeleniu
         public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
             Path tmpDir = Files.createTempDirectory("UnitTest");
             TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
-                    configurableApplicationContext, "embedded.selenium.vnc.record-dir=" + tmpDir.toAbsolutePath().toString());
+                    configurableApplicationContext, "embedded.selenium.vnc.recording-dir=" + tmpDir.toAbsolutePath().toString());
             TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
                     configurableApplicationContext, "embedded.selenium.vnc.wassetintest=" + true);
 


### PR DESCRIPTION
You need to call TestLifecycleAware#aftertest on the testcontainer class whenever tests are finished so that the BrowserWebDriverContainer actually saves the videos in the directory. This is the only implementation of the generic TestLifecycleAware#aftertest so it can stay in the selenium module for now IMHO.

I added a test case to ensure that tests videos are generated.

There is a known issue with the videos which I am not sure if I should document. The vidoes themselves do not allow fast forward.

To fix them you need to do the following:

ffmpeg -i <filename>  -acodec copy -vcodec copy <newfilename>
I might raise this issue in the testcontainers project.