### PR TITLE
Switch to using the docker.elastic.co registry

### DIFF
--- a/embedded-elasticsearch/src/main/java/com/playtika/test/elasticsearch/ElasticSearchProperties.java
+++ b/embedded-elasticsearch/src/main/java/com/playtika/test/elasticsearch/ElasticSearchProperties.java
@@ -36,7 +36,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("embedded.elasticsearch")
 public class ElasticSearchProperties extends CommonContainerProperties {
     public static final String BEAN_NAME_EMBEDDED_ELASTIC_SEARCH = "embeddedElasticSearch";
-    String dockerImage = "elasticsearch:7.7.0";
+    String dockerImage = "docker.elastic.co/elasticsearch/elasticsearch:7.7.0";
 
     String clusterName = "test_cluster";
     String host = "localhost";


### PR DESCRIPTION
The dockerImage property was specified with no registry prefix,
so was implicitly using the default docker.io one. This leads to
issues when trying to pull in newer images such as 7.10.0, which
are present in the docker.elastic.co registry, but not in the
docker.io one.

This fix switches the dockerImage value to the explicit image name
with the registry prefix, as well as adds a compatibility shim. If
the ambiguous image name of "elasticsearch:7.10.0" or a bare tag
is specified, the tag part is used with the default image of
"docker.elastic.co/elasticsearch/elasticsearch".