### PR TITLE
Use default withTimes setting for wait strategy with custom regex for…

### DIFF
--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
@@ -23,6 +23,10 @@
  */
 package com.playtika.test.postgresql;
 
+import static com.playtika.test.common.utils.ContainerUtils.configureCommonsAndStart;
+import static com.playtika.test.postgresql.PostgreSQLProperties.BEAN_NAME_EMBEDDED_POSTGRESQL;
+import static org.testcontainers.shaded.com.google.common.base.Strings.isNullOrEmpty;
+
 import com.playtika.test.common.spring.DockerPresenceBootstrapConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -39,10 +43,6 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.LinkedHashMap;
-
-import static com.playtika.test.common.utils.ContainerUtils.configureCommonsAndStart;
-import static com.playtika.test.postgresql.PostgreSQLProperties.BEAN_NAME_EMBEDDED_POSTGRESQL;
-import static org.testcontainers.shaded.com.google.common.base.Strings.isNullOrEmpty;
 
 @Slf4j
 @Configuration
@@ -68,8 +68,7 @@ public class EmbeddedPostgreSQLBootstrapConfiguration {
         String startupLogCheckRegex = properties.getStartupLogCheckRegex();
         if (!isNullOrEmpty(startupLogCheckRegex)) {
             WaitStrategy waitStrategy = new LogMessageWaitStrategy()
-                .withRegEx(startupLogCheckRegex)
-                .withTimes(2);
+                .withRegEx(startupLogCheckRegex);
             postgresql.setWaitStrategy(waitStrategy);
         }
 

--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
@@ -23,10 +23,6 @@
  */
 package com.playtika.test.postgresql;
 
-import static com.playtika.test.common.utils.ContainerUtils.configureCommonsAndStart;
-import static com.playtika.test.postgresql.PostgreSQLProperties.BEAN_NAME_EMBEDDED_POSTGRESQL;
-import static org.testcontainers.shaded.com.google.common.base.Strings.isNullOrEmpty;
-
 import com.playtika.test.common.spring.DockerPresenceBootstrapConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -43,6 +39,10 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.LinkedHashMap;
+
+import static com.playtika.test.common.utils.ContainerUtils.configureCommonsAndStart;
+import static com.playtika.test.postgresql.PostgreSQLProperties.BEAN_NAME_EMBEDDED_POSTGRESQL;
+import static org.testcontainers.shaded.com.google.common.base.Strings.isNullOrEmpty;
 
 @Slf4j
 @Configuration


### PR DESCRIPTION
I have tried to start the postgresql container with the example configuration:
```
embedded:
  postgresql:
    enabled: true
    docker-image: 'bitnami/postgresql:13.1.0'
    wait-timeout-in-seconds: 40
    command: '/opt/bitnami/scripts/postgresql/run.sh'
    startupLogCheckRegex: '.*database system is ready to accept connections.*'
```
However, the problem is that the custom regex is checked twice, but it occurs only once. So I removed the adjustment to the number of matches to make the default value take effect.