### PR TITLE
Added ability to use Aerospike EE Docker

### DIFF
--- a/embedded-aerospike/README.adoc
+++ b/embedded-aerospike/README.adoc
@@ -17,6 +17,7 @@
 * `embedded.aerospike.enabled` `(true|false, default is 'true')`
 * `embedded.aerospike.reuseContainer` `(true|false, default is 'false')`
 * `embedded.aerospike.dockerImage` `(default is set to 'aerospike/aerospike-server:4.3.0.8')`
+* `embedded.aerospike.featureKey` `(base64 of a feature-key-file https://docs.aerospike.com/docs/reference/configuration/index.html#feature-key-file, default is null) is only required for the EE image`
 ** You can pick wanted version on https://hub.docker.com/r/library/aerospike/tags/[dockerhub]
 * `embedded.aerospike.waitTimeoutInSeconds` `(default is 60 seconds)`
 *  https://mvnrepository.com/artifact/com.aerospike/aerospike-client[aerospike client library]

--- a/embedded-aerospike/src/main/java/com/playtika/test/aerospike/AerospikeProperties.java
+++ b/embedded-aerospike/src/main/java/com/playtika/test/aerospike/AerospikeProperties.java
@@ -40,4 +40,5 @@ public class AerospikeProperties extends CommonContainerProperties {
     String namespace = "TEST";
     String host = "localhost";
     int port = 3000;
+    String featureKey;
 }

--- a/embedded-aerospike/src/main/java/com/playtika/test/aerospike/EmbeddedAerospikeBootstrapConfiguration.java
+++ b/embedded-aerospike/src/main/java/com/playtika/test/aerospike/EmbeddedAerospikeBootstrapConfiguration.java
@@ -83,7 +83,13 @@ public class EmbeddedAerospikeBootstrapConfiguration {
                         .withEnv("STORAGE_GB", String.valueOf(1))
                         .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withCapAdd(Capability.NET_ADMIN))
                         .waitingFor(waitStrategy);
-
+        String featureKey = properties.featureKey;
+        if (featureKey != null) {
+            // see https://github.com/aerospike/aerospike-server-enterprise.docker/blob/master/aerospike.template.conf
+            aerospike
+                .withEnv("FEATURES", featureKey)
+                .withEnv("FEATURE_KEY_FILE", "env-b64:FEATURES");
+        }
         aerospike = configureCommonsAndStart(aerospike, properties, log);
         registerAerospikeEnvironment(aerospike, environment, properties);
         return aerospike;


### PR DESCRIPTION
In some cases, we should run our test on Aerospike EE Docker. For using this image we have to provide [feature-key](https://docs.aerospike.com/docs/reference/configuration/index.html#feature-key-file)