### PR TITLE
Expose Cassandra keyspace replication factor in properties and set it to 1 (Fixes #619)

### DIFF
--- a/embedded-cassandra/README.adoc
+++ b/embedded-cassandra/README.adoc
@@ -17,6 +17,7 @@
 * `embedded.cassandra.enabled` `(true|false, default is 'true')`
 * `embedded.cassandra.reuseContainer` `(true|false, default is 'false')`
 * `embedded.cassandra.keyspace-name` `(default is set to 'embedded')`
+* `embedded.cassandra.replication-factor` `(default is set to '1')`
 * `embedded.cassandra.dockerImage` `(default is set to 'cassandra:3.11.6')`
 ** You can pick the desired version on https://hub.docker.com/r/library/cassandra/tags/[dockerhub]
 

--- a/embedded-cassandra/src/main/java/com/playtika/test/cassandra/CassandraProperties.java
+++ b/embedded-cassandra/src/main/java/com/playtika/test/cassandra/CassandraProperties.java
@@ -38,4 +38,5 @@ public class CassandraProperties extends CommonContainerProperties {
     public String host = "localhost";
     public int port = 9042;
     public String keyspaceName = "embedded";
+    public int replicationFactor = 3;
 }

--- a/embedded-cassandra/src/main/java/com/playtika/test/cassandra/CassandraProperties.java
+++ b/embedded-cassandra/src/main/java/com/playtika/test/cassandra/CassandraProperties.java
@@ -38,5 +38,5 @@ public class CassandraProperties extends CommonContainerProperties {
     public String host = "localhost";
     public int port = 9042;
     public String keyspaceName = "embedded";
-    public int replicationFactor = 3;
+    public int replicationFactor = 1;
 }

--- a/embedded-cassandra/src/main/java/com/playtika/test/cassandra/EmbeddedCassandraBootstrapConfiguration.java
+++ b/embedded-cassandra/src/main/java/com/playtika/test/cassandra/EmbeddedCassandraBootstrapConfiguration.java
@@ -103,6 +103,7 @@ public class EmbeddedCassandraBootstrapConfiguration {
 
     private String prepareCassandraInitScript(CassandraProperties properties) {
         return FileUtils.resolveTemplateAsString(resourceLoader, "cassandra-init.sql", content -> content
-                .replace("{{keyspaceName}}", properties.keyspaceName));
+                .replace("{{keyspaceName}}", properties.keyspaceName))
+                .replace("{{replicationFactor}}", Integer.toString(properties.replicationFactor));
     }
 }

--- a/embedded-cassandra/src/main/resources/cassandra-init.sql.template
+++ b/embedded-cassandra/src/main/resources/cassandra-init.sql.template
@@ -1,1 +1,1 @@
-CREATE KEYSPACE {{keyspaceName}} WITH REPLICATION = { 'class':'SimpleStrategy', 'replication_factor' : 3 }
+CREATE KEYSPACE {{keyspaceName}} WITH REPLICATION = { 'class':'SimpleStrategy', 'replication_factor' : {{replicationFactor}} }


### PR DESCRIPTION
This PR exposes replication factor for default Cassandra keyspace as config property.
Also it sets default replication factor value to 1 because Cassandra cannot replicate rows when it not running in a cluster.

Fixes #619 