### PR TITLE
Enable Non-default images

### DIFF
--- a/embedded-neo4j/src/main/java/com/playtika/test/neo4j/EmbeddedNeo4jBootstrapConfiguration.java
+++ b/embedded-neo4j/src/main/java/com/playtika/test/neo4j/EmbeddedNeo4jBootstrapConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.LinkedHashMap;
 
@@ -55,7 +56,7 @@ public class EmbeddedNeo4jBootstrapConfiguration {
                                 Neo4jProperties properties) {
         log.info("Starting neo4j server. Docker image: {}", properties.dockerImage);
 
-        Neo4jContainer neo4j = new Neo4jContainer<>(properties.dockerImage)
+        Neo4jContainer neo4j = new Neo4jContainer<>(DockerImageName.parse(properties.dockerImage).asCompatibleSubstituteFor("neo4j"))
                 .withAdminPassword(properties.password)
                 .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig().withCapAdd(Capability.NET_ADMIN));
         neo4j = (Neo4jContainer) configureCommonsAndStart(neo4j, properties, log);


### PR DESCRIPTION
With this change, a user can use a custom image (for example in my case, one with apoc already installed) or even just one that is forced to be housed on a different server. Obviously, this might not always work with all custom images, but I think the users should be able to test with what they are actually going to be using in production.

This is my first pull request, but I figured I would just make the change since it's essentially one line instead of making a ticket and waiting for someone else to do it.