### PR TITLE
Log image build date on every container start

### DIFF
--- a/testcontainers-common/src/main/java/com/playtika/test/common/utils/DateUtils.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/utils/DateUtils.java
@@ -1,0 +1,153 @@
+package com.playtika.test.common.utils;
+
+
+import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * Convert ISO timestamps to human-readable relative times
+ */
+public class DateUtils {
+
+    /**
+     * @param isoFormattedDate ISO timestamp {@code "2021-12-31T23:59:59.123456789+18:00"}
+     * @return Combine original timestamp at local time zone truncated to seconds and human-readable relative time: {@code "2021-12-31T07:59:59+02:00 (1 year 2 months ago)"}
+     * @see #toTimeAgo(String)
+     */
+    public static String toDateAndTimeAgo(String isoFormattedDate) {
+        Object instantOrString = parseToInstantOrString(isoFormattedDate);
+        if (!(instantOrString instanceof Instant)) {
+            return (String) instantOrString;
+        }
+        Instant instant = ((Instant) instantOrString);
+        OffsetDateTime offsetDateTime = ((Instant) instantOrString).atZone(ZoneId.systemDefault()).toOffsetDateTime();
+        return offsetDateTime + " (" + toTimeAgo(instant.toEpochMilli()) + ")";
+    }
+
+    /**
+     * @param isoFormattedDate ISO timestamp {@code "2021-12-31T23:59:59.123456789+18:00"}
+     * @return human-readable relative time: {@code "1 year 2 months ago"}
+     * @see #toTimeAgo(long)
+     */
+    public static String toTimeAgo(String isoFormattedDate) {
+        Object instantOrString = parseToInstantOrString(isoFormattedDate);
+        return instantOrString instanceof Instant ? toTimeAgo(((Instant) instantOrString)
+            .toEpochMilli()) : (String) instantOrString;
+    }
+
+    /**
+     * @param isoFormattedDate ISO timestamp {@code "2021-12-31T23:59:59.123456789+18:00"}
+     * @return <ul>
+     * <li>Successfully parsed Instant object at UTC time zone truncated to seconds, i.e. {@code "2021-12-31T05:59:59Z"}</li>
+     * <li>{@code null} if isoFormattedDate is {@code null}</li>
+     * <li>{@code ""} empty string if isoFormattedDate is blank</li>
+     * <li>String containing the DateTimeParseException error message if isoFormattedDate is invalid</li>
+     * </ul>
+     * @see DateTimeFormatter#parse(CharSequence)
+     * @see Instant#from(TemporalAccessor)
+     */
+    static Object parseToInstantOrString(String isoFormattedDate) {
+        if (isoFormattedDate == null) {
+            return null;
+        }
+        if (StringUtils.isBlank(isoFormattedDate)) {
+            return "";
+        }
+        try {
+            return Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(isoFormattedDate))
+                          .with(ChronoField.NANO_OF_SECOND, 0);
+        } catch (DateTimeParseException e) {
+            return e.getMessage();
+        }
+    }
+
+    /**
+     * <p>Thresholds are 60 seconds, 50 minutes, 20 hours, 3 weeks, 10 months.<br>
+     * Everything else is rounded (1.5 becomes 2).<br>
+     * Surplus months except 1 are not rounded (1 year 2 months ago).<br>
+     * 1 month are 30.42 days.
+     * <ul>
+     *     <li>{@literal <}= 89 seconds: a minute ago</li>
+     *     <li>{@literal <}= 50 minutes: 50 minutes ago</li>
+     *     <li>{@literal <}= 89 minutes: an hour ago</li>
+     *     <li>{@literal <}= 20 hours: 20 hours ago</li>
+     *     <li>{@literal <}= 35 hours: yesterday</li>
+     *     <li>{@literal <}= 5 days: 5 days ago</li>
+     *     <li>{@literal <}= 10 days: a week ago</li>
+     *     <li>{@literal <}= 24 days: 3 weeks ago</li>
+     *     <li>{@literal <}= 45 days: a month ago</li>
+     *     <li>{@literal <}= 10 months: 10 months ago</li>
+     *     <li>{@literal <}= 13 months: a year ago</li>
+     *     <li>== 14 months: 1 year 2 months ago</li>
+     *     <li>== 23 months: 1 year 11 months ago</li>
+     * </ul>
+     * <pre>
+     *  0 sec = a minute ago
+     * 89 sec = a minute ago
+     * 90 sec = 2 minutes ago
+     * 50 min = 50 minutes ago
+     * 51 min = an hour ago
+     * 89 min = an hour ago
+     * 90 min = 2 hours ago
+     * 20 hrs = 20 hours ago
+     * 21 hrs = yesterday
+     * 35 hrs = yesterday
+     * 36 hrs = 2 days ago
+     *  5 day = 5 days ago
+     *  6 day = a week ago
+     * 10 day = a week ago
+     * 11 day = 2 weeks ago
+     * 17 day = 2 weeks ago
+     * 18 day = 3 weeks ago
+     * 24 day = 3 weeks ago
+     * 25 day = a month ago
+     * 45 day = a month ago
+     * 46 day = 2 months ago
+     * 10 mon = 10 months ago
+     * 11 mon = a year ago
+     * 13 mon = a year ago
+     * 14 mon = 1 year 2 months ago
+     * 23 mon = 1 year 11 months ago
+     * 25 mon = 2 years ago
+     * 26 mon = 2 years 2 months ago
+     * </pre>
+     * </p>
+     *
+     * @param epochMillis Unix time in milliseconds (since 1970-01-01)
+     * @return human readable relative time: {@code "1 year 2 months ago"}
+     */
+    public static String toTimeAgo(long epochMillis) {
+        long seconds = Instant.now().toEpochMilli() / 1000 - (epochMillis / 1000);
+        long minutes = Math.round(seconds / 60.0);
+        if (minutes <= 50) {
+            return minutes <= 1 ? "a minute ago" : minutes + " minutes ago";
+        }
+        long hours = Math.round(seconds / 3600.0);
+        if (hours <= 20) {
+            return hours == 1 ? "an hour ago" : hours + " hours ago";
+        }
+        long days = Math.round(seconds / 86400.0);
+        if (days <= 5) {
+            return days <= 1 ? "yesterday" : days + " days ago";
+        }
+        long weeks = Math.round(seconds / 604800.0);
+        if (weeks <= 3) {
+            return weeks <= 1 ? "a week ago" : weeks + " weeks ago";
+        }
+        long months = Math.round(seconds / 2628288.0); // 30.42 days per month
+        if (months <= 10) {
+            return months <= 1 ? "a month ago" : months + " months ago";
+        }
+        long years = months / 12; // 11 -> 0, 23 -> 1
+        months = months % 12;
+        return months <= 1 || years == 0 ? ((years <= 1 ? "a year" : years + " years") + " ago") : years + ((years <= 1 ? " year " : " years ") + months + " months ago");
+    }
+
+}

--- a/testcontainers-common/src/test/java/com/playtika/test/common/utils/DateUtilsTest.java
+++ b/testcontainers-common/src/test/java/com/playtika/test/common/utils/DateUtilsTest.java
@@ -48,38 +48,6 @@ class DateUtilsTest {
         return map;
     }
 
-    public static void main(String[] args) {
-        long now = Instant.now().toEpochMilli();
-        System.out.println(" 0 sec = " + DateUtils.toTimeAgo(now - 1000L * 0));
-        System.out.println("89 sec = " + DateUtils.toTimeAgo(now - 1000L * 89));
-        System.out.println("90 sec = " + DateUtils.toTimeAgo(now - 1000L * 90));
-        System.out.println("50 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 50));
-        System.out.println("51 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 51));
-        System.out.println("89 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 89));
-        System.out.println("90 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 90));
-        System.out.println("20 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 20));
-        System.out.println("21 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 21));
-        System.out.println("35 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 35));
-        System.out.println("36 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 36));
-        System.out.println(" 5 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 5));
-        System.out.println(" 6 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 6));
-        System.out.println("10 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 10));
-        System.out.println("11 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 11));
-        System.out.println("17 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 17));
-        System.out.println("18 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 18));
-        System.out.println("24 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 24));
-        System.out.println("25 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 25));
-        System.out.println("45 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 45));
-        System.out.println("46 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 46));
-        System.out.println("10 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 10));
-        System.out.println("11 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 11));
-        System.out.println("13 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 13));
-        System.out.println("14 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 14));
-        System.out.println("23 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 23));
-        System.out.println("25 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 25));
-        System.out.println("26 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 26));
-    }
-
     private static OffsetDateTime toOffsetDateTime(Instant now, Long time) {
         return now.minusMillis(time).with(ChronoField.NANO_OF_SECOND, 0).atZone(ZoneId.systemDefault())
                   .toOffsetDateTime();

--- a/testcontainers-common/src/test/java/com/playtika/test/common/utils/DateUtilsTest.java
+++ b/testcontainers-common/src/test/java/com/playtika/test/common/utils/DateUtilsTest.java
@@ -1,0 +1,136 @@
+package com.playtika.test.common.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateUtilsTest {
+
+    private static Map<Long, String> relativeTimeToStrings = createRelativeTimeToStringExamples();
+
+    private static Map<Long, String> createRelativeTimeToStringExamples() {
+        Map<Long, String> map = new LinkedHashMap<>();
+        map.put(1000L * 0, " 0 sec = a minute ago");
+        map.put(1000L * 89, "89 sec = a minute ago");
+        map.put(1000L * 90, "90 sec = 2 minutes ago");
+        map.put(1000L * 60 * 50, "50 min = 50 minutes ago");
+        map.put(1000L * 60 * 51, "51 min = an hour ago");
+        map.put(1000L * 60 * 89, "89 min = an hour ago");
+        map.put(1000L * 60 * 90, "90 min = 2 hours ago");
+        map.put(1000L * 60 * 60 * 20, "20 hrs = 20 hours ago");
+        map.put(1000L * 60 * 60 * 21, "21 hrs = yesterday");
+        map.put(1000L * 60 * 60 * 35, "35 hrs = yesterday");
+        map.put(1000L * 60 * 60 * 36, "36 hrs = 2 days ago");
+        map.put(1000L * 60 * 60 * 24 * 5, " 5 day = 5 days ago");
+        map.put(1000L * 60 * 60 * 24 * 6, " 6 day = a week ago");
+        map.put(1000L * 60 * 60 * 24 * 10, "10 day = a week ago");
+        map.put(1000L * 60 * 60 * 24 * 11, "11 day = 2 weeks ago");
+        map.put(1000L * 60 * 60 * 24 * 17, "17 day = 2 weeks ago");
+        map.put(1000L * 60 * 60 * 24 * 18, "18 day = 3 weeks ago");
+        map.put(1000L * 60 * 60 * 24 * 24, "24 day = 3 weeks ago");
+        map.put(1000L * 60 * 60 * 24 * 25, "25 day = a month ago");
+        map.put(1000L * 60 * 60 * 24 * 45, "45 day = a month ago");
+        map.put(1000L * 60 * 60 * 24 * 46, "46 day = 2 months ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 10, "10 mon = 10 months ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 11, "11 mon = a year ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 13, "13 mon = a year ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 14, "14 mon = 1 year 2 months ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 23, "23 mon = 1 year 11 months ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 25, "25 mon = 2 years ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 26, "26 mon = 2 years 2 months ago");
+        return map;
+    }
+
+    public static void main(String[] args) {
+        long now = Instant.now().toEpochMilli();
+        System.out.println(" 0 sec = " + DateUtils.toTimeAgo(now - 1000L * 0));
+        System.out.println("89 sec = " + DateUtils.toTimeAgo(now - 1000L * 89));
+        System.out.println("90 sec = " + DateUtils.toTimeAgo(now - 1000L * 90));
+        System.out.println("50 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 50));
+        System.out.println("51 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 51));
+        System.out.println("89 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 89));
+        System.out.println("90 min = " + DateUtils.toTimeAgo(now - 1000L * 60 * 90));
+        System.out.println("20 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 20));
+        System.out.println("21 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 21));
+        System.out.println("35 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 35));
+        System.out.println("36 hrs = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 36));
+        System.out.println(" 5 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 5));
+        System.out.println(" 6 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 6));
+        System.out.println("10 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 10));
+        System.out.println("11 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 11));
+        System.out.println("17 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 17));
+        System.out.println("18 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 18));
+        System.out.println("24 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 24));
+        System.out.println("25 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 25));
+        System.out.println("45 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 45));
+        System.out.println("46 day = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 46));
+        System.out.println("10 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 10));
+        System.out.println("11 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 11));
+        System.out.println("13 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 13));
+        System.out.println("14 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 14));
+        System.out.println("23 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 23));
+        System.out.println("25 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 25));
+        System.out.println("26 mon = " + DateUtils.toTimeAgo(now - 1000L * 60 * 60 * 24 * 30 * 26));
+    }
+
+    private static OffsetDateTime toOffsetDateTime(Instant now, Long time) {
+        return now.minusMillis(time).with(ChronoField.NANO_OF_SECOND, 0).atZone(ZoneId.systemDefault())
+                  .toOffsetDateTime();
+    }
+
+    private static OffsetDateTime toOffsetDateTimePlusNanoseconds(Instant now, Long time) {
+        return now.minusMillis(time).atZone(ZoneId.systemDefault()).toOffsetDateTime();
+    }
+
+    @Test
+    void toDateAndTimeAgo() {
+        Instant now = Instant.now();
+        relativeTimeToStrings.forEach((time, text) -> assertThat(DateUtils
+            .toDateAndTimeAgo(toOffsetDateTimePlusNanoseconds(now, time).toString()))
+            .as(toOffsetDateTime(now, time) + " = " + text).isEqualTo(String
+                .format("%s (%s)", toOffsetDateTime(now, time), text.split(" = ")[1])));
+    }
+
+    @Test
+    void toTimeAgoLong() {
+        Instant now = Instant.now();
+        relativeTimeToStrings.forEach((time, text) -> assertThat(DateUtils.toTimeAgo(now.toEpochMilli() - time))
+            .as(toOffsetDateTime(now, time) + " = " + text).isEqualTo(text.split(" = ")[1]));
+    }
+
+    @Test
+    void toTimeAgoString() {
+        Instant now = Instant.now();
+        relativeTimeToStrings.forEach((time, text) -> assertThat(DateUtils
+            .toTimeAgo(toOffsetDateTimePlusNanoseconds(now, time).toString()))
+            .as(toOffsetDateTime(now, time) + " = " + text).isEqualTo(text.split(" = ")[1]));
+    }
+
+    @Test
+    void parseToInstantOrString() {
+        assertThat(DateUtils.parseToInstantOrString(null)).isNull();
+        assertThat(DateUtils.parseToInstantOrString("")).isEqualTo("");
+        assertThat(DateUtils.parseToInstantOrString("   ")).isEqualTo("");
+        assertThat(DateUtils.parseToInstantOrString("yesterday"))
+            .isEqualTo("Text 'yesterday' could not be parsed at index 0");
+        assertThat(DateUtils.parseToInstantOrString("2021-12-31T23:59:59+23:00"))
+            .isEqualTo("Text '2021-12-31T23:59:59+23:00' could not be parsed: Zone offset not in valid range: -18:00 to +18:00");
+        assertThat(DateUtils.parseToInstantOrString("2021-12-31T23:59:59"))
+            .as("Zone offset like +05:00 is required")
+            .isEqualTo("Text '2021-12-31T23:59:59' could not be parsed at index 19");
+
+        Instant now = Instant.now();
+        relativeTimeToStrings.forEach((time, text) -> assertThat(DateUtils
+            .parseToInstantOrString(toOffsetDateTimePlusNanoseconds(now, time).toString()))
+            .as(toOffsetDateTime(now, time) + " = " + text)
+            .isEqualTo(now.minusMillis(time).with(ChronoField.NANO_OF_SECOND, 0)));
+    }
+
+}


### PR DESCRIPTION
Change "startup time is x seconds" log output to include the build date of the container image (ISO and relative date) in preparation to the upcoming version upgrades.