### PR TITLE
Upgrade container and SDK versions

### DIFF
--- a/embedded-consul/README.adoc
+++ b/embedded-consul/README.adoc
@@ -16,6 +16,8 @@
 
 * `embedded.consul.enabled` `(true|false, default is 'true')`
 * `embedded.consul.configurationFile` `(path for the consul configuration file to be mounted, relative to the resources folder, default is 'null')`
+* `embedded.consul.dockerImage` `(default is 'consul:1.10')`
+** Image versions on https://hub.docker.com/_/consul?tab=tags[dockerhub]
 
 Example spring configuration:
 
@@ -27,9 +29,9 @@ embedded:
     enabled: true
   consul:
     enabled: true
-    # file to be mounted in docker as '/consul/config/test-acl.hcl' 
+    # file to be mounted in docker as '/consul/config/test-acl.hcl'
     # path relative from the resources directory (usually 'src/test/resources')
-    configurationFile: consul/test-acl.hcl 
+    configurationFile: consul/test-acl.hcl
 ----
 
 ==== Produces

--- a/embedded-consul/src/main/java/com/playtika/test/consul/ConsulProperties.java
+++ b/embedded-consul/src/main/java/com/playtika/test/consul/ConsulProperties.java
@@ -10,7 +10,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("embedded.consul")
 public class ConsulProperties extends CommonContainerProperties {
     public static final String BEAN_NAME_EMBEDDED_CONSUL = "embeddedConsul";
-    private String dockerImage = "consul:1.9";
+    // https://hub.docker.com/_/consul
+    private String dockerImage = "consul:1.10";
     private int port = 8500;
     private String configurationFile = null;
 }

--- a/embedded-elasticsearch/README.adoc
+++ b/embedded-elasticsearch/README.adoc
@@ -16,7 +16,7 @@
 
 * `embedded.elasticsearch.enabled` `(true|false, default is true)`
 * `embedded.elasticsearch.reuseContainer` `(true|false, default is false)`
-* `embedded.elasticsearch.dockerImage` `(default is 'docker.elastic.co/elasticsearch/elasticsearch:7.13.4')`
+* `embedded.elasticsearch.dockerImage` `(default is 'docker.elastic.co/elasticsearch/elasticsearch:7.14.0')`
 ** Image versions on https://www.docker.elastic.co/r/elasticsearch[docker.elastic.co]
 * `embedded.elasticsearch.indices` `(indices to create, no indices are created by default)`
 * `embedded.elasticsearch.waitTimeoutInSeconds` `(default is 60 seconds)`

--- a/embedded-elasticsearch/src/main/java/com/playtika/test/elasticsearch/ElasticSearchProperties.java
+++ b/embedded-elasticsearch/src/main/java/com/playtika/test/elasticsearch/ElasticSearchProperties.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class ElasticSearchProperties extends CommonContainerProperties {
     public static final String BEAN_NAME_EMBEDDED_ELASTIC_SEARCH = "embeddedElasticSearch";
     // https://hub.docker.com/_/elasticsearch
-    String dockerImage = "docker.elastic.co/elasticsearch/elasticsearch:7.13.4";
+    String dockerImage = "docker.elastic.co/elasticsearch/elasticsearch:7.14.0";
 
     String clusterName = "test_cluster";
     String host = "localhost";

--- a/embedded-google-pubsub/README.adoc
+++ b/embedded-google-pubsub/README.adoc
@@ -16,7 +16,7 @@
 
 * `embedded.google.pubsub.enabled` `(true|false, default is true)`
 * `embedded.google.pubsub.reuseContainer` `(true|false, default is false)`
-* `embedded.google.pubsub.dockerImage` `(default is 'google/cloud-sdk:350.0.0')`
+* `embedded.google.pubsub.dockerImage` `(default is 'google/cloud-sdk:351.0.0')`
 ** Image versions on https://hub.docker.com/r/google/cloud-sdk/tags[dockerhub]
 * `embedded.google.pubsub.host` `(default is 0.0.0.0)`
 * `embedded.google.pubsub.port` `(default is 8089)`

--- a/embedded-google-pubsub/src/main/java/com/playtika/test/pubsub/PubsubProperties.java
+++ b/embedded-google-pubsub/src/main/java/com/playtika/test/pubsub/PubsubProperties.java
@@ -15,7 +15,7 @@ public class PubsubProperties extends CommonContainerProperties {
     public static final String BEAN_NAME_EMBEDDED_GOOGLE_PUBSUB = "embeddedGooglePubsub";
     // https://hub.docker.com/r/google/cloud-sdk
     // Only the full image "latest" (or just the version number) and the much smaller "emulators" contain all components needed for testing pubsub
-    public static final String BASE_DOCKER_IMAGE = "google/cloud-sdk:350.0.0";
+    public static final String BASE_DOCKER_IMAGE = "google/cloud-sdk:351.0.0";
     private String dockerImage = BASE_DOCKER_IMAGE;
     private String host = "0.0.0.0";
     private int port = 8089;

--- a/embedded-grafana/README.adoc
+++ b/embedded-grafana/README.adoc
@@ -16,7 +16,7 @@
 
 * `embedded.grafana.enabled` `(true|false, default is true)`
 * `embedded.grafana.reuseContainer` `(true|false, default is false)`
-* `embedded.grafana.dockerImage` `(default is 'grafana/grafana:8.0.6')`
+* `embedded.grafana.dockerImage` `(default is 'grafana/grafana:8.1.0')`
 ** Image versions on https://hub.docker.com/r/grafana/grafana/tags[dockerhub]
 * `embedded.grafana.networkAlias` `(default is 'grafana')`
 * `embedded.grafana.username` `(default is 'admin')`

--- a/embedded-grafana/src/main/java/com/playtika/test/grafana/GrafanaProperties.java
+++ b/embedded-grafana/src/main/java/com/playtika/test/grafana/GrafanaProperties.java
@@ -14,7 +14,7 @@ public class GrafanaProperties extends CommonContainerProperties {
 
     boolean enabled = true;
     // https://hub.docker.com/r/grafana/grafana
-    String dockerImage = "grafana/grafana:8.0.6";
+    String dockerImage = "grafana/grafana:8.1.0";
     String networkAlias = "grafana";
     String username = "admin";
     String password = "password";

--- a/embedded-keycloak/pom.xml
+++ b/embedded-keycloak/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>embedded-keycloak</artifactId>
 
     <properties>
-        <keycloak.version>15.0.0</keycloak.version>
+        <keycloak.version>15.0.1</keycloak.version>
     </properties>
 
     <dependencies>

--- a/embedded-localstack/pom.xml
+++ b/embedded-localstack/pom.xml
@@ -14,7 +14,7 @@
     <version>2.0.12-SNAPSHOT</version>
 
     <properties>
-        <aws-java-sdk.version>1.12.37</aws-java-sdk.version>
+        <aws-java-sdk.version>1.12.42</aws-java-sdk.version>
     </properties>
 
     <dependencies>

--- a/embedded-minio/README.adoc
+++ b/embedded-minio/README.adoc
@@ -15,7 +15,7 @@
 ==== Consumes (via `bootstrap.properties`)
 * `embedded.minio.enabled` `(true|false, default is true)`
 * `embedded.minio.reuseContainer` `(true|false, default is false)`
-* `embedded.minio.dockerImage` `(default is 'minio/minio:RELEASE.2021-07-27T02-40-15Z')`
+* `embedded.minio.dockerImage` `(default is 'minio/minio:RELEASE.2021-08-05T22-01-19Z')`
 ** Image versions on https://hub.docker.com/r/minio/minio/tags[dockerhub]
 * `embedded.minio.accessKey` `(default is 'AKIAIOSFODNN7EXAMPLE")`
 * `embedded.minio.secretKey` `(default is 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')`

--- a/embedded-minio/src/main/java/com/playtika/test/minio/MinioProperties.java
+++ b/embedded-minio/src/main/java/com/playtika/test/minio/MinioProperties.java
@@ -37,7 +37,7 @@ public class MinioProperties extends CommonContainerProperties {
     static final String MINIO_BEAN_NAME = "minio";
 
     // https://hub.docker.com/r/minio/minio
-    String dockerImage = "minio/minio:RELEASE.2021-07-27T02-40-15Z";
+    String dockerImage = "minio/minio:RELEASE.2021-08-05T22-01-19Z";
     String accessKey = "AKIAIOSFODNN7EXAMPLE";
     String secretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
     String userName = "root";

--- a/embedded-vault/README.adoc
+++ b/embedded-vault/README.adoc
@@ -16,7 +16,7 @@
 
 * `embedded.vault.enabled` `(true|false, default is true)`
 * `embedded.vault.reuseContainer` `(true|false, default is false)`
-* `embedded.vault.dockerImage` `(default is 'vault:1.8.0')`
+* `embedded.vault.dockerImage` `(default is 'vault:1.8.1')`
 ** Image versions on https://hub.docker.com/_/vault?tab=tags[dockerhub]
 * `embedded.vault.host` `(default is 'localhost')`
 * `embedded.vault.port` `(int, default is 8200)`

--- a/embedded-vault/src/main/java/com/playtika/test/vault/VaultProperties.java
+++ b/embedded-vault/src/main/java/com/playtika/test/vault/VaultProperties.java
@@ -39,7 +39,7 @@ public class VaultProperties extends CommonContainerProperties {
     static final String BEAN_NAME_EMBEDDED_VAULT = "embeddedVault";
 
     // https://hub.docker.com/_/vault
-    private String dockerImage = "vault:1.8.0";
+    private String dockerImage = "vault:1.8.1";
     private String host = "localhost";
     /**
      * The container internal port. Will be overwritten with mapped port.


### PR DESCRIPTION
Containers:
* Consul 1.9.8 to 1.10.1
* Elasticsearch 7.13.4 to 7.14.0
* Google Cloud SDK 350.0.0 to 351.0.0
* Grafana 8.0.6 to 8.1.0
* MinIO 2021-07-27 to 2021-08-05
* Vault 1.8.0 to 1.8.1

SDK / Clients:
* aws-java-sdk-s3 1.12.37 to 1.12.42
* keycloak-core 15.0.0 to 15.0.1