### PR TITLE
Improve logging

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -170,6 +170,14 @@ NOTE: embedded.kafka.enabled=false will cause DockerNotPresentException if you d
 |null
 |key-value map of additional environment variables. Where key is name of variable and value is actual value of it.
 
+|embedded.{module-name}.logBuildDate
+|true
+|Enables logging of container build date.
+
+|embedded.{module-name}.logBuildTime
+|false
+|Enables logging of container build time (no effect if logBuildDate=false).
+
 |embedded.{module-name}.filesToInclude
 | empty list
 |List of files to include objects.

--- a/embedded-aerospike/src/main/java/com/playtika/test/aerospike/AerospikeProperties.java
+++ b/embedded-aerospike/src/main/java/com/playtika/test/aerospike/AerospikeProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.aerospike;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.aerospike")

--- a/embedded-cassandra/src/main/java/com/playtika/test/cassandra/CassandraProperties.java
+++ b/embedded-cassandra/src/main/java/com/playtika/test/cassandra/CassandraProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.cassandra;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.cassandra")

--- a/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/ClickHouseProperties.java
+++ b/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/ClickHouseProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.clickhouse;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.clickhouse")

--- a/embedded-consul/src/main/java/com/playtika/test/consul/ConsulProperties.java
+++ b/embedded-consul/src/main/java/com/playtika/test/consul/ConsulProperties.java
@@ -3,8 +3,10 @@ package com.playtika.test.consul;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.consul")

--- a/embedded-couchbase/src/main/java/com/playtika/test/couchbase/CouchbaseProperties.java
+++ b/embedded-couchbase/src/main/java/com/playtika/test/couchbase/CouchbaseProperties.java
@@ -26,6 +26,7 @@ package com.playtika.test.couchbase;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.testcontainers.couchbase.CouchbaseService;
 
@@ -34,6 +35,7 @@ import static java.lang.String.format;
 /**
  * https://blog.couchbase.com/testing-spring-data-couchbase-applications-with-testcontainers/
  */
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.couchbase")

--- a/embedded-dynamodb/src/main/java/com/playtika/test/dynamodb/DynamoDBProperties.java
+++ b/embedded-dynamodb/src/main/java/com/playtika/test/dynamodb/DynamoDBProperties.java
@@ -26,13 +26,15 @@ package com.playtika.test.dynamodb;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.dynamodb")
 public class DynamoDBProperties extends CommonContainerProperties {
-    
+
     static final String BEAN_NAME_EMBEDDED_DYNAMODB = "embeddedDynamoDb";
 
     String dockerImage = "amazon/dynamodb-local:latest";

--- a/embedded-elasticsearch/src/main/java/com/playtika/test/elasticsearch/ElasticSearchProperties.java
+++ b/embedded-elasticsearch/src/main/java/com/playtika/test/elasticsearch/ElasticSearchProperties.java
@@ -26,11 +26,13 @@ package com.playtika.test.elasticsearch;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.elasticsearch")

--- a/embedded-google-pubsub/src/main/java/com/playtika/test/pubsub/PubsubProperties.java
+++ b/embedded-google-pubsub/src/main/java/com/playtika/test/pubsub/PubsubProperties.java
@@ -3,11 +3,13 @@ package com.playtika.test.pubsub;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.Collection;
 import java.util.Collections;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.google.pubsub")

--- a/embedded-grafana/src/main/java/com/playtika/test/grafana/GrafanaProperties.java
+++ b/embedded-grafana/src/main/java/com/playtika/test/grafana/GrafanaProperties.java
@@ -3,8 +3,10 @@ package com.playtika.test.grafana;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.grafana")

--- a/embedded-influxdb/src/main/java/com/playtika/test/influxdb/InfluxDBProperties.java
+++ b/embedded-influxdb/src/main/java/com/playtika/test/influxdb/InfluxDBProperties.java
@@ -2,10 +2,12 @@ package com.playtika.test.influxdb;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.playtika.test.common.properties.CommonContainerProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.influxdb")

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/KafkaConfigurationProperties.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/KafkaConfigurationProperties.java
@@ -30,6 +30,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.With;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import javax.annotation.PostConstruct;
@@ -37,6 +38,7 @@ import javax.validation.constraints.AssertTrue;
 import java.util.Collection;
 import java.util.Collections;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.kafka")

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/SchemaRegistryConfigurationProperties.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/SchemaRegistryConfigurationProperties.java
@@ -26,12 +26,14 @@ package com.playtika.test.kafka.properties;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import static com.playtika.test.kafka.properties.SchemaRegistryConfigurationProperties.Authentication.BASIC;
 import static com.playtika.test.kafka.properties.SchemaRegistryConfigurationProperties.Authentication.NONE;
 import static com.playtika.test.kafka.properties.SchemaRegistryConfigurationProperties.AvroCompatibilityLevel.BACKWARD;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.kafka.schema-registry")

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/ZookeeperConfigurationProperties.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/properties/ZookeeperConfigurationProperties.java
@@ -26,10 +26,12 @@ package com.playtika.test.kafka.properties;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import static java.lang.String.format;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.zookeeper")

--- a/embedded-keycloak/src/main/java/com/playtika/test/keycloak/KeycloakProperties.java
+++ b/embedded-keycloak/src/main/java/com/playtika/test/keycloak/KeycloakProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.keycloak;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.keycloak")

--- a/embedded-localstack/src/main/java/com/playtika/test/localstack/LocalStackProperties.java
+++ b/embedded-localstack/src/main/java/com/playtika/test/localstack/LocalStackProperties.java
@@ -3,12 +3,14 @@ package com.playtika.test.localstack;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
 import java.util.Collection;
 import java.util.Collections;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.localstack")

--- a/embedded-mariadb/src/main/java/com/playtika/test/mariadb/MariaDBProperties.java
+++ b/embedded-mariadb/src/main/java/com/playtika/test/mariadb/MariaDBProperties.java
@@ -26,9 +26,11 @@ package com.playtika.test.mariadb;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.mariadb")

--- a/embedded-memsql/src/main/java/com/playtika/test/memsql/MemSqlProperties.java
+++ b/embedded-memsql/src/main/java/com/playtika/test/memsql/MemSqlProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.memsql;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.memsql")

--- a/embedded-minio/src/main/java/com/playtika/test/minio/MinioProperties.java
+++ b/embedded-minio/src/main/java/com/playtika/test/minio/MinioProperties.java
@@ -27,8 +27,10 @@ package com.playtika.test.minio;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.minio")

--- a/embedded-mongodb/src/main/java/com/playtika/test/mongodb/MongodbProperties.java
+++ b/embedded-mongodb/src/main/java/com/playtika/test/mongodb/MongodbProperties.java
@@ -3,8 +3,10 @@ package com.playtika.test.mongodb;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.mongodb")

--- a/embedded-mysql/src/main/java/com/playtika/test/mysql/MySQLProperties.java
+++ b/embedded-mysql/src/main/java/com/playtika/test/mysql/MySQLProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.mysql;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.mysql")

--- a/embedded-neo4j/src/main/java/com/playtika/test/neo4j/Neo4jProperties.java
+++ b/embedded-neo4j/src/main/java/com/playtika/test/neo4j/Neo4jProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.neo4j;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.neo4j")

--- a/embedded-oracle-xe/src/main/java/com/playtika/test/oracle/OracleProperties.java
+++ b/embedded-oracle-xe/src/main/java/com/playtika/test/oracle/OracleProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.oracle;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.oracle")

--- a/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
+++ b/embedded-postgresql/src/main/java/com/playtika/test/postgresql/PostgreSQLProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.postgresql;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.postgresql")

--- a/embedded-prometheus/src/main/java/com/playtika/test/prometheus/PrometheusProperties.java
+++ b/embedded-prometheus/src/main/java/com/playtika/test/prometheus/PrometheusProperties.java
@@ -3,8 +3,10 @@ package com.playtika.test.prometheus;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.prometheus")

--- a/embedded-pulsar/src/main/java/com/playtika/test/pulsar/PulsarProperties.java
+++ b/embedded-pulsar/src/main/java/com/playtika/test/pulsar/PulsarProperties.java
@@ -3,8 +3,10 @@ package com.playtika.test.pulsar;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.pulsar")

--- a/embedded-rabbitmq/src/main/java/com/playtika/test/rabbitmq/RabbitMQProperties.java
+++ b/embedded-rabbitmq/src/main/java/com/playtika/test/rabbitmq/RabbitMQProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.rabbitmq;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.rabbitmq")

--- a/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
+++ b/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
@@ -26,11 +26,13 @@ package com.playtika.test.redis;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.SocketUtils;
 
 import javax.annotation.PostConstruct;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.redis")

--- a/embedded-selenium/src/main/java/com/playtika/test/selenium/SeleniumProperties.java
+++ b/embedded-selenium/src/main/java/com/playtika/test/selenium/SeleniumProperties.java
@@ -26,6 +26,7 @@ import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import lombok.experimental.Accessors;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -34,6 +35,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.selenium")

--- a/embedded-vault/src/main/java/com/playtika/test/vault/VaultProperties.java
+++ b/embedded-vault/src/main/java/com/playtika/test/vault/VaultProperties.java
@@ -26,11 +26,13 @@ package com.playtika.test.vault;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.vault")

--- a/embedded-vertica/src/main/java/com/playtika/test/vertica/VerticaProperties.java
+++ b/embedded-vertica/src/main/java/com/playtika/test/vertica/VerticaProperties.java
@@ -3,8 +3,10 @@ package com.playtika.test.vertica;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.vertica")

--- a/embedded-voltdb/src/main/java/com/playtika/test/voltdb/VoltDBProperties.java
+++ b/embedded-voltdb/src/main/java/com/playtika/test/voltdb/VoltDBProperties.java
@@ -26,8 +26,10 @@ package com.playtika.test.voltdb;
 import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Accessors(chain = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.voltdb")

--- a/testcontainers-common/src/main/java/com/playtika/test/common/properties/CommonContainerProperties.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/properties/CommonContainerProperties.java
@@ -27,6 +27,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.With;
+import lombok.experimental.Accessors;
 import org.springframework.validation.annotation.Validated;
 import org.testcontainers.containers.BindMode;
 
@@ -41,6 +42,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 @Validated
+@Accessors(chain = true)
 @Data
 public class CommonContainerProperties {
 
@@ -60,6 +62,18 @@ public class CommonContainerProperties {
      * Whether to pull a docker image each time.
      */
     private boolean usePullAlwaysPolicy = false;
+    /**
+     * Log container build date (if false, logBuildTime is overriden too).
+     * == true:  log date
+     * == false: don't log date (and time)
+     */
+    private boolean logBuildDate = true;
+    /**
+     * Log container build time.
+     * == true:  log time (if logBuildDate == true)
+     * == false: don't log time
+     */
+    private boolean logBuildTime = false;
     private String[] command;
     private Map<String, String> env = emptyMap();
     @Valid

--- a/testcontainers-common/src/test/java/com/playtika/test/common/utils/DateUtilsTest.java
+++ b/testcontainers-common/src/test/java/com/playtika/test/common/utils/DateUtilsTest.java
@@ -18,7 +18,7 @@ class DateUtilsTest {
     private static Map<Long, String> createRelativeTimeToStringExamples() {
         Map<Long, String> map = new LinkedHashMap<>();
         map.put(1000L * 0, " 0 sec = a minute ago");
-        map.put(1000L * 89, "89 sec = a minute ago");
+        map.put(1000L * 88, "88 sec = a minute ago");
         map.put(1000L * 90, "90 sec = 2 minutes ago");
         map.put(1000L * 60 * 50, "50 min = 50 minutes ago");
         map.put(1000L * 60 * 51, "51 min = an hour ago");
@@ -43,8 +43,10 @@ class DateUtilsTest {
         map.put(1000L * 60 * 60 * 24 * 30 * 13, "13 mon = a year ago");
         map.put(1000L * 60 * 60 * 24 * 30 * 14, "14 mon = 1 year 2 months ago");
         map.put(1000L * 60 * 60 * 24 * 30 * 23, "23 mon = 1 year 11 months ago");
-        map.put(1000L * 60 * 60 * 24 * 30 * 25, "25 mon = 2 years ago");
-        map.put(1000L * 60 * 60 * 24 * 30 * 26, "26 mon = 2 years 2 months ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 29, "29 mon = 2 years ago");
+        map.put(1000L * 60 * 60 * 24 * 30 * 30, "30 mon = 3 years ago");
+        map.put(1000L * 60 * 60 * 24 * 35 * 30, "35 mon = 3 years ago");
+        map.put(Instant.now().toEpochMilli(), "EPOCH (1970-01-01) = (no date / reproducible build)");
         return map;
     }
 


### PR DESCRIPTION
* Don't log time by default anymore, instead allow setting `logBuildTime` if needed.
* Allow to disable logging of build date by setting `logBuildDate = false`.
* Log EPOCH (1970-01-01) as `(no date / reproducible build)`.
* `containerLogsConsumer` trims messages, logs errors to stderr and skips last message if empty.
* Allow to start containers without providing a logger, or with a custom logConsumer.

If possible, consider removing the `UtilityClass` annotation to allow instance methods and make a builder pattern possible instead of static methods for all of the supported argument combinations.