### PR TITLE
#697 added azurite support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -273,6 +273,8 @@ Available values can be taken from `com.github.dockerjava.api.model.Capability` 
 
 === link:embedded-artifactory/README.adoc[embedded-artifactory]
 
+=== link:embedded-azurite/README.adoc[embedded-azurite]
+
 == How to contribute
 
 === Flow

--- a/embedded-azurite/README.adoc
+++ b/embedded-azurite/README.adoc
@@ -1,0 +1,47 @@
+=== embedded-azurite
+
+==== Maven dependency
+
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>com.playtika.testcontainers</groupId>
+    <artifactId>embedded-azurite</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+==== Consumes (via `bootstrap.properties`)
+* `embedded.azurite.enabled` `(true|false, default is true)`
+* `embedded.azurite.reuseContainer` `(true|false, default is false)`
+* `embedded.azurite.dockerImage` `(default is 'mcr.microsoft.com/azure-storage/azurite')`
+** Image versions on https://hub.docker.com/_/microsoft-azure-storage-azurite
+* `embedded.azurite.port` `(default is 1000)`
+
+Account name and account key are hardcoded as of https://github.com/Azure/Azurite#default-storage-account.
+
+==== Produces
+
+* `embedded.minio.host`
+* `embedded.minio.port`
+* `embedded.minio.account-name`
+* `embedded.minio.account-key`
+* `embedded.minio.blob-endpoint` (computed property `http://${host}:${port}/${accountName}` for convient configuration with `azure-spring-boot-starter-storage`)
+
+==== Example
+
+Use `com.azure.spring:azure-spring-boot-starter-storage` (see https://docs.microsoft.com/en-us/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-storage)
+and configure your application context as follows:
+
+[source,yaml]
+./src/test/resources/application.yaml
+----
+azure:
+  storage:
+    account-name: ${embedded.azurite.account-name}
+    account-key: ${embedded.azurite.account-key}
+    blob-endpoint: ${embedded.azurite.blob-endpoint}
+----
+
+You can then access all beans from `azure-spring-boot-starter-storage`, i.e. `BlobServiceClientBuilder`.

--- a/embedded-azurite/README.adoc
+++ b/embedded-azurite/README.adoc
@@ -17,7 +17,7 @@
 * `embedded.azurite.reuseContainer` `(true|false, default is false)`
 * `embedded.azurite.dockerImage` `(default is 'mcr.microsoft.com/azure-storage/azurite')`
 ** Image versions on https://hub.docker.com/_/microsoft-azure-storage-azurite
-* `embedded.azurite.port` `(default is 1000)`
+* `embedded.azurite.port` `(default is 10000)`
 
 Account name and account key are hardcoded as of https://github.com/Azure/Azurite#default-storage-account.
 

--- a/embedded-azurite/pom.xml
+++ b/embedded-azurite/pom.xml
@@ -21,7 +21,7 @@
             <groupId>com.azure.spring</groupId>
             <artifactId>azure-spring-boot-starter-storage</artifactId>
             <version>${azure.version}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.playtika.testcontainers</groupId>

--- a/embedded-azurite/pom.xml
+++ b/embedded-azurite/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>testcontainers-spring-boot-parent</artifactId>
+        <groupId>com.playtika.testcontainers</groupId>
+        <version>2.0.20-SNAPSHOT</version>
+        <relativePath>../testcontainers-spring-boot-parent</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>embedded-azurite</artifactId>
+
+    <properties>
+        <azure.version>3.12.0</azure.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.azure.spring</groupId>
+            <artifactId>azure-spring-boot-starter-storage</artifactId>
+            <version>${azure.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.playtika.testcontainers</groupId>
+            <artifactId>testcontainers-common</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteContainer.java
+++ b/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteContainer.java
@@ -1,0 +1,23 @@
+package com.playtika.test.azurite;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/azure-storage/azurite");
+
+    public AzuriteContainer(String tag) {
+        super(DEFAULT_IMAGE_NAME.withTag(tag));
+    }
+
+    /**
+     * can't be changed, see https://github.com/Azure/Azurite#default-storage-account
+     */
+    static final String ACCOUNT_NAME = "devstoreaccount1";
+
+    /**
+     * can't be changed, see https://github.com/Azure/Azurite#default-storage-account
+     */
+    static final String ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+}

--- a/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteProperties.java
+++ b/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteProperties.java
@@ -1,0 +1,22 @@
+package com.playtika.test.azurite;
+
+import com.playtika.test.common.properties.CommonContainerProperties;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ConfigurationProperties("embedded.azurite")
+public class AzuriteProperties extends CommonContainerProperties {
+
+    static final String AZURITE_BEAN_NAME = "azurite";
+
+    /**
+     * Using the latest version on purpose here, because there also always exists always one version of Azure.
+     * If you want a fixed version, check https://hub.docker.com/_/microsoft-azure-storage-azurite
+     */
+    String dockerImageVersion = "latest";
+
+    int port = 10000;
+}

--- a/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteProperties.java
+++ b/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteProperties.java
@@ -12,11 +12,7 @@ public class AzuriteProperties extends CommonContainerProperties {
 
     static final String AZURITE_BEAN_NAME = "azurite";
 
-    /**
-     * Using the latest version on purpose here, because there also always exists always one version of Azure.
-     * If you want a fixed version, check https://hub.docker.com/_/microsoft-azure-storage-azurite
-     */
-    String dockerImageVersion = "latest";
+    String dockerImageVersion = "3.15.0";
 
     int port = 10000;
 }

--- a/embedded-azurite/src/main/java/com/playtika/test/azurite/EmbeddedAzuriteBootstrapConfiguration.java
+++ b/embedded-azurite/src/main/java/com/playtika/test/azurite/EmbeddedAzuriteBootstrapConfiguration.java
@@ -1,0 +1,60 @@
+package com.playtika.test.azurite;
+
+import com.playtika.test.common.spring.DockerPresenceBootstrapConfiguration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.LinkedHashMap;
+
+import static com.playtika.test.common.utils.ContainerUtils.configureCommonsAndStart;
+
+@Slf4j
+@Configuration
+@ConditionalOnExpression("${embedded.containers.enabled:true}")
+@AutoConfigureAfter(DockerPresenceBootstrapConfiguration.class)
+@ConditionalOnProperty(name = "embedded.azurite.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(AzuriteProperties.class)
+public class EmbeddedAzuriteBootstrapConfiguration {
+
+    @Bean(name = AzuriteProperties.AZURITE_BEAN_NAME, destroyMethod = "stop")
+    public AzuriteContainer azurite(ConfigurableEnvironment environment,
+                                    AzuriteProperties properties) {
+
+        AzuriteContainer container = new AzuriteContainer(properties.getDockerImageVersion())
+                .withExposedPorts(properties.getPort());
+
+        configureCommonsAndStart(container, properties, log);
+
+        registerEnvironment(container, environment, properties);
+
+        return container;
+    }
+
+    private void registerEnvironment(AzuriteContainer azurite,
+                                     ConfigurableEnvironment environment,
+                                     AzuriteProperties properties) {
+
+        Integer mappedPort = azurite.getMappedPort(properties.getPort());
+        String host = azurite.getContainerIpAddress();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.azurite.host", host);
+        map.put("embedded.azurite.port", mappedPort);
+        map.put("embedded.azurite.account-name", azurite.ACCOUNT_NAME);
+        map.put("embedded.azurite.account-key", azurite.ACCOUNT_KEY);
+        map.put("embedded.azurite.blob-endpoint", "http://" + host + ":" + mappedPort + "/" + azurite.ACCOUNT_NAME);
+
+        log.info("Started Azurite. Connection details: {}", map);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedAzuriteInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+    }
+
+}

--- a/embedded-azurite/src/main/resources/META-INF/spring.factories
+++ b/embedded-azurite/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+  com.playtika.test.azurite.EmbeddedAzuriteBootstrapConfiguration

--- a/embedded-azurite/src/test/java/com/playtika/test/azurite/DisableAzuriteTest.java
+++ b/embedded-azurite/src/test/java/com/playtika/test/azurite/DisableAzuriteTest.java
@@ -1,0 +1,27 @@
+package com.playtika.test.azurite;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Order(1)
+class DisableAzuriteTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(EmbeddedAzuriteBootstrapConfiguration.class));
+
+    @Test
+    @DisplayName("ensures the azurite container is not being created when azurite is disabled")
+    void contextLoads() {
+        contextRunner
+                .withPropertyValues(
+                        "embedded.azurite.enabled=false"
+                )
+                .run((context) -> assertThat(context)
+                        .hasNotFailed()
+                        .doesNotHaveBean(AzuriteProperties.AZURITE_BEAN_NAME));
+    }
+}

--- a/embedded-azurite/src/test/java/com/playtika/test/azurite/EmbeddedAzuriteBoostrapConfigurationTest.java
+++ b/embedded-azurite/src/test/java/com/playtika/test/azurite/EmbeddedAzuriteBoostrapConfigurationTest.java
@@ -1,0 +1,45 @@
+package com.playtika.test.azurite;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = EmbeddedAzuriteBoostrapConfigurationTest.AzuriteTestConfiguration.class)
+class EmbeddedAzuriteBoostrapConfigurationTest {
+
+    @Autowired
+    BlobServiceClientBuilder blobServiceClientBuilder;
+
+    @Test
+    void accountName() {
+        BlobServiceClient blobServiceClient = blobServiceClientBuilder.buildClient();
+        assertThat(blobServiceClient.getAccountName()).isEqualTo(AzuriteContainer.ACCOUNT_NAME);
+    }
+
+    @Test
+    @DisplayName("do some basic operations to show that azurite is running and working correctly")
+    void createAndDeleteContainer() {
+        BlobServiceClient blobServiceClient = blobServiceClientBuilder.buildClient();
+        long containersBefore = blobServiceClient.listBlobContainers().stream().count();
+        BlobContainerClient container = blobServiceClient.createBlobContainer(UUID.randomUUID().toString());
+        assertThat(container.listBlobs().stream()).isEmpty();
+        assertThat(blobServiceClient.listBlobContainers().stream().count()).isEqualTo(containersBefore + 1);
+        container.delete();
+        assertThat(blobServiceClient.listBlobContainers().stream().count()).isEqualTo(containersBefore);
+    }
+
+    @EnableAutoConfiguration
+    public static class AzuriteTestConfiguration {
+
+    }
+
+}

--- a/embedded-azurite/src/test/resources/application.yaml
+++ b/embedded-azurite/src/test/resources/application.yaml
@@ -1,0 +1,5 @@
+azure:
+  storage:
+    account-name: ${embedded.azurite.account-name}
+    account-key: ${embedded.azurite.account-key}
+    blob-endpoint: ${embedded.azurite.blob-endpoint}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <module>embedded-consul</module>
         <module>embedded-db2</module>
         <module>embedded-artifactory</module>
+        <module>embedded-azurite</module>
     </modules>
 
     <properties>

--- a/testcontainers-spring-boot-bom/pom.xml
+++ b/testcontainers-spring-boot-bom/pom.xml
@@ -165,6 +165,11 @@
                 <artifactId>embedded-db2</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.playtika.testcontainers</groupId>
+                <artifactId>embedded-azurite</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
This would be a possible fix for https://github.com/Playtika/testcontainers-spring-boot/issues/697, it adds support for Azurite, the local version of Azure Storage

- see https://github.com/Azure/Azurite
- being tested with https://docs.microsoft.com/en-us/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-storage